### PR TITLE
[WIP] Build the C++ components as shared libraries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,4 +129,5 @@ out/*
 
 # CMake generates this file on the fly
 setup.py
-qiskit/backends/qiskit_simulator
+qiskit/libs/qiskit_simulator.py
+qiskit/libs/_qiskit_simulator*.so

--- a/.pylintrc
+++ b/.pylintrc
@@ -32,7 +32,7 @@ unsafe-load-any-extension=no
 # A comma-separated list of package or module names from where C extensions may
 # be loaded. Extensions are loading into the active Python interpreter and may
 # run arbitrary code
-extension-pkg-whitelist=numpy
+extension-pkg-whitelist=numpy,qiskit.libs._qiskit_simulator_swig
 
 # Allow optimization of some AST trees. This will activate a peephole AST
 # optimizer, which will apply various small optimizations. For instance, it can

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,6 +60,7 @@ stage_linux: &stage_linux
         - liblapack-dev
         - libblas-dev
         - g++-5
+        - swig
 
 stage_osx: &stage_osx
   <<: *stage_generic
@@ -72,9 +73,10 @@ stage_osx: &stage_osx
     # installed manually.
     |
     if [ ${TRAVIS_OS_NAME} = "osx" ]; then
-      brew install python3
+      brew upgrade python
       brew install gcc@6
       brew link --overwrite gcc@6
+      brew install swig
       virtualenv env -p python3
       source env/bin/activate
     fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,9 @@ if (ENABLE_TARGETS_NON_PYTHON)
     # Add Python distributable package generator
     include(cmake/python-build.cmake)
     add_pypi_package_target(pypi_package both)
+
+    # SWIG components
+    include(cmake/swig.cmake)
 endif()
 
 include(cmake/tests.cmake)

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,7 +1,5 @@
 include qiskit/qasm/libs/*.inc
 recursive-include src/qiskit-simulator *
-include qiskit/backends/qiskit_simulator
-include qiskit/backends/qiskit_simulator.exe
 include qiskit/backends/*.dll
 include CMakeLists.txt
 include cmake/*.cmake

--- a/cmake/defaults.cmake
+++ b/cmake/defaults.cmake
@@ -4,6 +4,6 @@
 #
 
 set(CMAKE_BUILD_TYPE "Release")
-set(STATIC_LINKING True CACHE BOOL "Static linking of executables")
+set(STATIC_LINKING False CACHE BOOL "Static linking of executables")
 set(ENABLE_TARGETS_NON_PYTHON True CACHE BOOL "Enable targets for non Python code")
 set(ENABLE_TARGETS_QA True CACHE BOOL "Enable targets for QA targets")

--- a/cmake/swig.cmake
+++ b/cmake/swig.cmake
@@ -1,0 +1,18 @@
+# Creates targets for the generation of the non-python components that use
+# SWIG.
+
+# Set the output directory for the files produced by SWIG.
+# NOTE: each component should ensure that the final shared library is generated
+# in ${CMAKE_SWIG_OUTDIR}
+set(CMAKE_SWIG_OUTDIR ${CMAKE_BINARY_DIR}/swig)
+
+# Add targets.
+add_custom_target(swig_build)
+add_custom_target(swig_install)
+add_dependencies(swig_install swig_build)
+
+# Add each component to the "swig_build" target.
+# QISKit C++ Simulator
+add_subdirectory(${PROJECT_SOURCE_DIR}/src/qiskit-simulator/src/swig)
+add_dependencies(swig_build _qiskit_simulator_swig)
+

--- a/qiskit/backends/_qiskit_cpp_simulator.py
+++ b/qiskit/backends/_qiskit_cpp_simulator.py
@@ -120,9 +120,10 @@ def run(qobj):
 
     # Call the shared library.
     try:
-        cin = json.dumps(qobj).encode()
+        cin = json.dumps(qobj)
+        print(type(cin))
         cout = external_run(cin)
-        cresult = json.loads(cout.decode())
+        cresult = json.loads(cout)
 
         if 'result' in cresult:
             # If not Clifford simulator parse JSON complex numbers in output

--- a/qiskit/backends/_qiskit_cpp_simulator.py
+++ b/qiskit/backends/_qiskit_cpp_simulator.py
@@ -22,34 +22,32 @@ Interface to C++ quantum circuit simulator with realistic noise.
 import json
 import logging
 import numbers
-import os
-import subprocess
-from subprocess import PIPE
-import platform
 
 import numpy as np
 
+from qiskit import QISKitError
 from qiskit._result import Result
 from qiskit.backends import BaseBackend
 
+try:
+    # pylint: disable=invalid-name
+    from qiskit.libs import _qiskit_simulator_swig
+    external_run = _qiskit_simulator_swig.run
+except ImportError:
+    # pylint: disable=invalid-name
+    external_run = None
+
+
 logger = logging.getLogger(__name__)
-
-EXTENSION = '.exe' if platform.system() == 'Windows' else ''
-
-# Add path to compiled qiskit simulator
-DEFAULT_SIMULATOR_PATHS = [
-    # This is the path where Makefile creates the simulator by default
-    os.path.abspath(os.path.dirname(__file__) + \
-                    '../../../out/src/qiskit-simulator/qiskit_simulator' + EXTENSION),
-    # This is the path where PIP installs the simulator
-    os.path.abspath(os.path.dirname(__file__) + '/qiskit_simulator' + EXTENSION),
-]
 
 
 class QISKitCppSimulator(BaseBackend):
     """C++ quantum circuit simulator with realistic noise"""
 
     def __init__(self, configuration=None):
+        if not external_run:
+            raise QISKitError('Cpp simulator shared library not available.')
+
         super().__init__(configuration)
         self._configuration = configuration
 
@@ -64,24 +62,9 @@ class QISKitCppSimulator(BaseBackend):
                 "basis_gates": 'u1,u2,u3,cx,id,x,y,z,h,s,sdg,t,tdg,wait,noise,save,load,uzz',
             }
 
-        # Try to use the default executable if not specified.
-        if self._configuration.get('exe'):
-            paths = [self._configuration.get('exe')]
-        else:
-            paths = DEFAULT_SIMULATOR_PATHS
-
-        # Ensure that the executable is available.
-        try:
-            self._configuration['exe'] = next(
-                path for path in paths if (os.path.exists(path) and
-                                           os.path.getsize(path) > 100))
-        except StopIteration:
-            raise FileNotFoundError('Simulator executable not found (using %s)' %
-                                    self._configuration.get('exe', 'default locations'))
-
     def run(self, q_job):
         qobj = q_job.qobj
-        result = run(qobj, self._configuration['exe'])
+        result = run(qobj)
         return Result(result, qobj)
 
 
@@ -89,6 +72,9 @@ class CliffordCppSimulator(BaseBackend):
     """"C++ Clifford circuit simulator with realistic noise."""
 
     def __init__(self, configuration=None):
+        if not external_run:
+            raise QISKitError('Cpp simulator shared library not available.')
+
         super().__init__(configuration)
         self._configuration = configuration
 
@@ -103,21 +89,6 @@ class CliffordCppSimulator(BaseBackend):
                 'basis_gates': 'cx,id,x,y,z,h,s,sdg,wait,noise,save,load'
             }
 
-        # Try to use the default executable if not specified.
-        if self._configuration.get('exe'):
-            paths = [self._configuration.get('exe')]
-        else:
-            paths = DEFAULT_SIMULATOR_PATHS
-
-        # Ensure that the executable is available.
-        try:
-            self._configuration['exe'] = next(
-                path for path in paths if (os.path.exists(path) and
-                                           os.path.getsize(path) > 100))
-        except StopIteration:
-            raise FileNotFoundError('Simulator executable not found (using %s)' %
-                                    self._configuration.get('exe', 'default locations'))
-
     def run(self, q_job):
         qobj = q_job.qobj
         # set backend to Clifford simulator
@@ -126,17 +97,16 @@ class CliffordCppSimulator(BaseBackend):
         else:
             qobj['config'] = {'simulator': 'clifford'}
 
-        result = run(qobj, self._configuration['exe'])
+        result = run(qobj)
         return Result(result, qobj)
 
 
-def run(qobj, executable):
+def run(qobj):
     """
     Run simulation on C++ simulator inside a subprocess.
 
     Args:
         qobj (dict): qobj dictionary defining the simulation to run
-        executable (string): filename (with path) of the simulator executable
     Returns:
         dict: A dict of simulation results
     """
@@ -148,16 +118,10 @@ def run(qobj, executable):
             qobj['circuits'][j]['config'] = __to_json_complex(
                 qobj['circuits'][j]['config'])
 
-    # Open subprocess and execute external command
+    # Call the shared library.
     try:
-        with subprocess.Popen([executable, '-'],
-                              stdin=PIPE, stdout=PIPE, stderr=PIPE) as proc:
-            cin = json.dumps(qobj).encode()
-            cout, cerr = proc.communicate(cin)
-        if cerr:
-            logger.error('ERROR: Simulator encountered a runtime error: %s',
-                         cerr.decode())
-
+        cin = json.dumps(qobj).encode()
+        cout = external_run(cin)
         cresult = json.loads(cout.decode())
 
         if 'result' in cresult:
@@ -169,9 +133,8 @@ def run(qobj, executable):
                         if 'noise_params' in result:
                             __parse_noise_params(result['noise_params'])
         return cresult
-
-    except FileNotFoundError:
-        msg = "ERROR: Simulator exe not found at: %s" % executable
+    except QISKitError as exc:
+        msg = "ERROR: run() failed: : %s" % str(exc)
         logger.error(msg)
         return {"status": msg, "success": False}
 

--- a/setup.py.in
+++ b/setup.py.in
@@ -15,16 +15,17 @@
 # limitations under the License.
 # =============================================================================
 
-import sys
 import os
 import platform
-from distutils.command.build import build
+
+from distutils import log
+from distutils.dir_util import mkpath
+from distutils.file_util import copy_file
 from multiprocessing import cpu_count
 from subprocess import call
 
-from setuptools import setup
-from setuptools.dist import Distribution
-
+from setuptools import setup, Extension
+from setuptools.command.build_ext import build_ext
 
 requirements = [
     "IBMQuantumExperience>=1.8.26",
@@ -44,6 +45,7 @@ packages = ["qiskit",
             "qiskit.extensions.standard",
             "qiskit.extensions.qiskit_simulator",
             "qiskit.extensions.quantum_initializer",
+            "qiskit.libs",
             "qiskit.mapper",
             "qiskit.qasm",
             "qiskit.qasm._node",
@@ -54,65 +56,143 @@ packages = ["qiskit",
             "qiskit.tools.qi"]
 
 
-# C++ components compilation
-class QiskitSimulatorBuild(build):
-    def run(self):
-        super().run()
-        # Store the current working directory, as invoking cmake involves
-        # an out of source build and might interfere with the rest of the steps.
-        current_directory = os.getcwd()
+class CMakeError(Exception):
+    pass
+
+
+class CMakeWrapper(object):
+    """
+    Utility class for invoking `cmake` commands.
+
+    Note: stdout is silenced by pip if the full setup.py invocation is
+        successful, unless using '-v' - hence the warnings might not be
+        displayed to the end user.
+    """
+    def __init__(self, cmake_dir='out'):
+        self.cmake_dir = os.path.abspath(cmake_dir)
+        self.cmd_make_extra_args = []
+        self.create_cmake_dir()
+
+    def create_cmake_dir(self):
+        """
+        Create the out of source cmake directory, setting the flags passed to
+        cmake based on the platform and available features.
+
+        Raises:
+            CMakeError: if `cmake` could not be found, or its invocation
+                resulted in an error.
+        """
+        # Check for supported platforms
+        supported_platforms = ['Linux', 'Darwin', 'Windows']
+        current_platform = platform.system()
+        if current_platform not in supported_platforms:
+            log.warning(
+                'The QISKit extensions are only supported currently under the '
+                'following platforms: {}'.format(supported_platforms))
+            raise CMakeError('Unsupported platform')
+
+        # Prepare the flags for the `cmake` command.
+        cmd_cmake = ['cmake', '-vvv']
+        if 'USER_LIB_PATH' in os.environ:
+            cmd_cmake.append('-DUSER_LIB_PATH={}'.format(
+                os.environ['USER_LIB_PATH']))
+        if current_platform == 'Windows':
+            # We only support MinGW so far
+            cmd_cmake.append("-GMinGW Makefiles")
+        cmd_cmake.append(os.path.abspath('.'))
+
+        # Prepare the flags for the `make` commands.
+        try:
+            self.cmd_make_extra_args.append('-j%d' % cpu_count())
+        except NotImplementedError:
+            log.warning('Unable to determine number of CPUs. Using single '
+                        'threaded make.')
+
+        # Run cmake for creating the out of source folder.
+        try:
+            log.info('Creating the cmake out of source directory')
+            mkpath(self.cmake_dir)
+            call(cmd_cmake, cwd=self.cmake_dir)
+        except Exception as e:
+            log.error('The initial cmake command could not be executed. '
+                      'Please check that cmake and the dependencies for the '
+                      'extensions are installed: %s' % str(e))
+            raise CMakeError(str(e))
+
+    def run_make_target(self, target, args=None):
+        """
+        Run a `make` target inside the cmake directory.
+        Args:
+            target (str): name of the target to run.
+            args (None or list): list of extra parameters for the target.
+
+        Raises:
+            CMakeError: if the make target returned an error.
+        """
+        args = args or []
+        cmd_make = ['make', target] + args + self.cmd_make_extra_args
 
         try:
-            supported_platforms = ['Linux', 'Darwin', 'Windows']
-            current_platform = platform.system()
-            if current_platform not in supported_platforms:
-                # TODO: stdout is silenced by pip if the full setup.py invocation is
-                # successful, unless using '-v' - hence the warnings are not printed.
-                print('WARNING: QISKit cpp simulator is meant to be built with these '
-                      'platforms: {}. We will support other platforms soon!'
-                      .format(supported_platforms))
-                return
-
-            cmd_cmake = ['cmake', '-vvv']
-            if 'USER_LIB_PATH' in os.environ:
-                cmd_cmake.append('-DUSER_LIB_PATH={}'.format(os.environ['USER_LIB_PATH']))
-            if current_platform == 'Windows':
-                # We only support MinGW so far
-                cmd_cmake.append("-GMinGW Makefiles")
-            cmd_cmake.append('..')
-
-            cmd_make = ['make', 'pypi_package_copy_qiskit_simulator']
-
-            try:
-                cmd_make.append('-j%d' % cpu_count())
-            except NotImplementedError:
-                print('WARNING: Unable to determine number of CPUs. Using single threaded make.')
-
-            def compile_simulator():
-                self.mkpath('out')
-                os.chdir('out')
-                call(cmd_cmake)
-                call(cmd_make)
-
-            self.execute(compile_simulator, [], 'Compiling QISKit C++ Simulator')
+            log.info('Building cmake target "%s"' % target)
+            call(cmd_make, cwd=self.cmake_dir)
         except Exception as e:
-            print(str(e))
-            print("WARNING: Seems like the cpp simulator can't be built, Qiskit will "
-                  "install anyway, but won't have this simulator support.")
-
-        # Restore working directory.
-        os.chdir(current_directory)
+            log.error('Unable to build target "%s": %s' % (target,
+                                                           str(e)))
+            raise CMakeError(str(e))
 
 
-# This is for creating wheel specific platforms
-class BinaryDistribution(Distribution):
-    def has_ext_modules(self):
-        return True
+class BuildCMakeExt(build_ext):
+    def run(self):
+        """Build extensions in build directory, then copy if --inplace"""
+        # Copy the files generated by cmake to the build directory, mimicking
+        # the default compilation.
+
+        # Try to initialize cmake.
+        self.cmake_path = os.path.join(self.build_temp, 'out')
+        try:
+            cmake_wrapper = CMakeWrapper(self.cmake_path)
+        except CMakeError:
+            return
+
+        for ext in self.extensions:
+            try:
+                source_so = ext.sources[0]
+                sources_other = ext.sources[1:]
+
+                # Get the names and paths used.
+                fullname = self.get_ext_fullname(ext.name)
+                shortname = fullname.split('.')[-1]
+                filename = self.get_ext_filename(fullname)
+                extension_dir = os.path.dirname(os.path.join(self.build_lib,
+                                                             filename))
+
+                # Execute cmake to invoke the target
+                cmake_wrapper.run_make_target(shortname)
+
+                # Copy the files to the temporary build directory. The first
+                # .so file is renamed to the  platform specific name, and the
+                # rest are copied as-is.
+                self.mkpath(extension_dir)
+                copy_file(os.path.join(self.cmake_path, source_so),
+                          os.path.join(extension_dir, os.path.basename(filename)))
+                for other_file in sources_other:
+                    copy_file(os.path.join(self.cmake_path, other_file),
+                              os.path.join(extension_dir,
+                                           os.path.basename(other_file)))
+            except CMakeError as e:
+                # TODO: cleanup in case a single extension fails to build
+                log.warning('Error building "%s": %s' % (ext.name, str(e)))
+
+        old_inplace, self.inplace = self.inplace, 0
+
+        self.inplace = old_inplace
+        if old_inplace:
+            self.copy_extensions_to_source()
 
 
 setup(
     name="qiskit",
-    version="${QISKIT_VERSION}",
+    version="0.5.0",
     description="Software for developing quantum computing programs",
     long_description="""QISKit is a software development kit for writing
         quantum computing experiments, programs, and applications. Works with
@@ -138,11 +218,13 @@ setup(
     install_requires=requirements,
     include_package_data=True,
     python_requires=">=3.5",
-    cmdclass={
-        'build': QiskitSimulatorBuild,
-    },
-    distclass=BinaryDistribution,
     extras_require={
         'ProjectQ':  ["projectq>=0.3.6"],
-    }
+    },
+    cmdclass={
+        "build_ext": BuildCMakeExt,
+    },
+    ext_modules=[Extension('qiskit.libs._qiskit_simulator_swig',
+                           sources=['swig/_qiskit_simulator_swig.so',
+                                    'swig/qiskit_simulator_swig.py'])],
 )

--- a/src/qiskit-simulator/CMakeLists.txt
+++ b/src/qiskit-simulator/CMakeLists.txt
@@ -23,20 +23,32 @@
 project(qiskit_simulator VERSION 1.0 LANGUAGES CXX)
 
 set(QISKIT_SIMULATOR_SRC_DIR "${PROJECT_SOURCE_DIR}/src")
-set(QISKIT_SIMULATOR_SRC
-    "${QISKIT_SIMULATOR_SRC_DIR}/main.cpp")
+set(QISKIT_SIMULATOR_SRC "${QISKIT_SIMULATOR_SRC_DIR}/main.cpp")
+set(QISKIT_SIMULATOR_HPP "${QISKIT_SIMULATOR_SRC_DIR}/qiskit_simulator.hpp")
 set(QISKIT_SIMULATOR_EXTERNAL_LIBS
     "${QISKIT_SIMULATOR_SRC_DIR}/third-party/headers"
     "${QISKIT_SIMULATOR_SRC_DIR}/third-party/win64/lib"
 	"${USER_LIB_PATH}")
 
-# Target definition
-add_executable(qiskit_simulator ${QISKIT_SIMULATOR_SRC})
+# Target definitions:
+# - the "qiskit_simulator" target produces the library (it automatically sets
+#   the name of the final filename to "libqiskit_simulator.xxx").
+# - the "qiskit_simulator_binary" target produces a standalone executable.
+add_executable(qiskit_simulator_binary ${QISKIT_SIMULATOR_SRC})
+if (STATIC_LINKING OR MINGW)
+    add_library(qiskit_simulator STATIC ${QISKIT_SIMULATOR_SRC} ${QISKIT_SIMULATOR_HPP})
+else()
+    add_library(qiskit_simulator SHARED ${QISKIT_SIMULATOR_SRC} ${QISKIT_SIMULATOR_HPP})
+endif()
+set_target_properties(qiskit_simulator PROPERTIES
+    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/libs")
 
 # Target properties: C++ program
+set_target_properties(qiskit_simulator_binary PROPERTIES LINKER_LANGUAGE CXX)
 set_target_properties(qiskit_simulator PROPERTIES LINKER_LANGUAGE CXX)
 
 # Toolchain options
+set_property(TARGET qiskit_simulator_binary PROPERTY CXX_STANDARD 14)
 set_property(TARGET qiskit_simulator PROPERTY CXX_STANDARD 14)
 
 # Compiler flags
@@ -69,11 +81,14 @@ enable_cxx_compiler_flag_if_supported("-Wredundant-decls")
 enable_cxx_compiler_flag_if_supported("-Wshadow")
 enable_cxx_compiler_flag_if_supported("-Woverloaded-virtual")
 
-target_include_directories(qiskit_simulator PRIVATE ${QISKIT_SIMULATOR_SRC_DIR})
-target_include_directories(qiskit_simulator PRIVATE ${QISKIT_SIMULATOR_SRC_DIR}/backends)
-target_include_directories(qiskit_simulator PRIVATE ${QISKIT_SIMULATOR_SRC_DIR}/engines)
-target_include_directories(qiskit_simulator PRIVATE ${QISKIT_SIMULATOR_SRC_DIR}/utilities)
-target_include_directories(qiskit_simulator PRIVATE ${QISKIT_SIMULATOR_SRC_DIR}/third-party/headers)
+set(CUSTOM_INCLUDE_DIRECTORIES
+    ${QISKIT_SIMULATOR_SRC_DIR}
+    ${QISKIT_SIMULATOR_SRC_DIR}/backends
+    ${QISKIT_SIMULATOR_SRC_DIR}/engines
+    ${QISKIT_SIMULATOR_SRC_DIR}/utilities
+    ${QISKIT_SIMULATOR_SRC_DIR}/third-party/headers)
+target_include_directories(qiskit_simulator_binary PRIVATE ${CUSTOM_INCLUDE_DIRECTORIES})
+target_include_directories(qiskit_simulator PRIVATE ${CUSTOM_INCLUDE_DIRECTORIES})
 
 # For header only libraries
 SET(CMAKE_FIND_LIBRARY_PREFIXES ${CMAKE_FIND_LIBRARY_PREFIXES} "")
@@ -117,12 +132,13 @@ endif()
 
 set(LIBRARIES PRIVATE ${LIB_BLAS}
                       ${LIB_LAPACK}
-					  ${LIB_THREADS})
+			          ${LIB_THREADS})
 
 # Linking
+target_link_libraries(qiskit_simulator_binary PRIVATE ${LIBRARIES})
 target_link_libraries(qiskit_simulator ${LIBRARIES})
 
-set(QISKIT_SIMULATOR_OUTPUT_DIR $<TARGET_FILE_DIR:qiskit_simulator>
+set(QISKIT_SIMULATOR_OUTPUT_DIR $<TARGET_FILE_DIR:qiskit_simulator_binary>
 	CACHE INTERNAL "Output directory for building QISKit C++ Simulator")
 
 if(MINGW)
@@ -134,7 +150,7 @@ if(MINGW)
 
 	foreach(dll_file ${QISKIT_SIMULATOR_THIRD_PARTY_DLLS})
 		add_custom_command(
-			TARGET qiskit_simulator
+			TARGET qiskit_simulator_binary
 			POST_BUILD
 			COMMAND ${CMAKE_COMMAND}
 			ARGS -E copy ${dll_file} ${QISKIT_SIMULATOR_OUTPUT_DIR}/

--- a/src/qiskit-simulator/src/qiskit_simulator.hpp
+++ b/src/qiskit-simulator/src/qiskit_simulator.hpp
@@ -1,0 +1,4 @@
+/**
+ * Public interface for the SWIG generated component for the QISKit simulator.
+ */
+std::string run(std::string json_in);

--- a/src/qiskit-simulator/src/swig/CMakeLists.txt
+++ b/src/qiskit-simulator/src/swig/CMakeLists.txt
@@ -1,0 +1,36 @@
+# CMake config file to build SWIG wrapper and library for the C++ simulator
+
+project(qiskit_simulator_swixg CXX)
+
+set(QISKIT_SIMULATOR_SRC_DIR "${PROJECT_SOURCE_DIR}/..")
+set(QISKIT_SIMULATOR_SRC_SWIG "${PROJECT_SOURCE_DIR}/qiskit_simulator_swig.i")
+
+# Generic checks and directives for using SWIG.
+find_package(SWIG REQUIRED)
+include(${SWIG_USE_FILE})
+find_package(PythonLibs REQUIRED)
+include_directories(${PYTHON_INCLUDE_PATH})
+set(CUSTOM_INCLUDE_DIRECTORIES
+    ${QISKIT_SIMULATOR_SRC_DIR}
+    ${QISKIT_SIMULATOR_SRC_DIR}/backends
+    ${QISKIT_SIMULATOR_SRC_DIR}/engines
+    ${QISKIT_SIMULATOR_SRC_DIR}/utilities
+    ${QISKIT_SIMULATOR_SRC_DIR}/third-party/headers)
+
+set_source_files_properties(${QISKIT_SIMULATOR_SRC_SWIG} PROPERTIES CPLUSPLUS True)
+set(CMAKE_SWIG_FLAGS "-I${QISKIT_SIMULATOR_SRC_DIR}")
+
+# Target for the SWIG shared library ("_qiskit_simulator_swig")
+if (${CMAKE_VERSION} VERSION_LESS "3.8.0")
+    swig_add_module(qiskit_simulator_swig python ${QISKIT_SIMULATOR_SRC_SWIG})
+else()
+    # swig_add_module() is deprecated in cmake 3.8.0.
+    swig_add_library(qiskit_simulator_swig SHARED LANGUAGE python SOURCES
+        ${QISKIT_SIMULATOR_SRC_SWIG})
+endif()
+
+target_include_directories(_qiskit_simulator_swig PRIVATE ${QISKIT_SIMULATOR_SRC_DIR})
+set_target_properties(_qiskit_simulator_swig PROPERTIES
+    LIBRARY_OUTPUT_DIRECTORY ${CMAKE_SWIG_OUTDIR})
+
+swig_link_libraries(qiskit_simulator_swig ${PYTHON_LIBRARIES} qiskit_simulator)

--- a/src/qiskit-simulator/src/swig/qiskit_simulator_swig.i
+++ b/src/qiskit-simulator/src/swig/qiskit_simulator_swig.i
@@ -1,0 +1,10 @@
+%module qiskit_simulator_swig
+%include <std_string.i>
+
+// Add necessary symbols to generated header
+%{
+#include "qiskit_simulator.hpp"
+%}
+
+// Process symbols in header
+%include "qiskit_simulator.hpp"

--- a/test/python/test_local_qiskit_simulator.py
+++ b/test/python/test_local_qiskit_simulator.py
@@ -22,7 +22,7 @@ import unittest
 
 import qiskit
 import qiskit.backends._qiskit_cpp_simulator as qiskitsimulator
-from qiskit import ClassicalRegister
+from qiskit import ClassicalRegister, QISKitError
 from qiskit import QuantumCircuit
 from qiskit import QuantumJob
 from qiskit import QuantumRegister
@@ -80,9 +80,9 @@ class TestLocalQiskitSimulator(QiskitTestCase):
     def test_run_qobj(self):
         try:
             simulator = qiskitsimulator.QISKitCppSimulator()
-        except FileNotFoundError as fnferr:
+        except QISKitError as fnferr:
             raise unittest.SkipTest(
-                'cannot find {} in path'.format(fnferr))
+                'cannot find Cpp simulator: {}'.format(fnferr))
         result = simulator.run(self.q_job)
 
         # TODO: reenable the assertEqual with the exact counts once the issue


### PR DESCRIPTION
Add the skeleton for building the C++ components as shared libraries
using swig, instead of using executables:
* modify the CMake configuration:
  * `cmake/swig.cmake`: adds `swig_build` and `swig_install`, generic
    targets that invoke the targets for each component.
  * `qiskit-simulator/src/swig/CMakeLists.txt`: adds the targets for
    the swig compilation of the C++ simulator.
  * `qiskit-simulator/CMakeLists.txt`: adds a target for building the
    library, renaming the building of the simulator as an executable
    to `qiskit_simulator_binary` for backwards-compatibility.
* update the C++ simulator source, adding a `run()` method as the entry
  point for accessing it via Python.
* update `qiskit/backends/_qiskit_cpp_simulator.py`, checking for the
  import of the shared library instead of the presence of the binary.
* modify `setup.py` using a custom `build_ext` command that invokes
  CMake, for taking advantage of the streamlined `python setup.py
  build_ext` command.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.