### PR TITLE
[WIP] Cython based building and linking of C++ simulator

### DIFF
--- a/src/qasm-simulator-cpp/cython-build-example/README.md
+++ b/src/qasm-simulator-cpp/cython-build-example/README.md
@@ -1,0 +1,13 @@
+# Example of building and linking C++ simulator using Cython
+
+The cython library can be build by navigating to this directory and then running:
+
+```
+python example_setup.py build_ext --inplace
+```
+
+An example of calling the simulator from python can then be run using
+
+```
+python example_simulation.py
+```

--- a/src/qasm-simulator-cpp/cython-build-example/example_setup.py
+++ b/src/qasm-simulator-cpp/cython-build-example/example_setup.py
@@ -1,0 +1,72 @@
+import sys
+import os
+from distutils.core import setup, Extension
+from distutils.spawn import find_executable
+from Cython.Build import cythonize
+from numpy.__config__ import get_info as np_config
+
+# Build options
+include = ['-I../src',
+           '-I../src/backends',
+           '-I../src/engines',
+           '-I../src/utilities',
+           '-I../src/third-party',
+           '-I../src/third-party/headers']
+warnings = ['-pedantic', '-Wall', '-Wextra', '-Wfloat-equal', '-Wundef',
+            '-Wcast-align', '-Wwrite-strings', '-Wmissing-declarations',
+            '-Wshadow', '-Woverloaded-virtual']
+opt = ['-ffast-math', '-O3', '-march=native']
+extra_compile_args = ['-g', '-std=c++11'] + opt + include + warnings
+extra_link_args = []
+libraries = []
+library_dirs = []
+include_dirs = []
+
+# Numpy BLAS
+blas_info = np_config('blas_mkl_info')
+if blas_info == {}:
+    blas_info = np_config('blas_opt_info')
+extra_compile_args += blas_info.get('extra_compile_args', [])
+extra_link_args += blas_info.get('extra_link_args', [])
+libraries += blas_info.get('libraries', [])
+library_dirs += blas_info.get('library_dirs', [])
+include_dirs += blas_info.get('include_dirs', [])
+
+# MacOS Specific build instructions
+if sys.platform == 'darwin':
+
+    # Set minimum os version to support C++11 headers
+    min_macos_version = '-mmacosx-version-min=10.9'
+    extra_compile_args.append(min_macos_version)
+    extra_link_args.append(min_macos_version)
+
+    # Check for OpenMP compatible GCC compiler
+    for gcc in ['g++-7', 'g++-6', 'g++-5']:
+        path = find_executable(gcc)
+        if path is not None:
+            # Use most recent GCC compiler
+            os.environ['CC'] = path
+            os.environ['CXX'] = path
+            extra_compile_args.append('-fopenmp')
+            extra_link_args.append('-fopenmp')
+            break
+else:
+    # Linux and Windows
+    extra_compile_args.append('-fopenmp')
+    extra_link_args.append('-fopenmp')
+
+# Simulator extension
+qasm_simulator = Extension('qasm_simulator',
+                           sources=['qasm_simulator.pyx'],
+                           extra_link_args=extra_link_args,
+                           extra_compile_args=extra_compile_args,
+                           libraries=libraries,
+                           library_dirs=library_dirs,
+                           include_dirs=include_dirs,
+                           language='c++')
+
+setup(
+    name='qasm_simulator',
+    packages=['qasm_simulator'],
+    ext_modules=cythonize(qasm_simulator)
+)

--- a/src/qasm-simulator-cpp/cython-build-example/example_setup.py
+++ b/src/qasm-simulator-cpp/cython-build-example/example_setup.py
@@ -6,21 +6,25 @@ from Cython.Build import cythonize
 from numpy.__config__ import get_info as np_config
 
 # Build options
-include = ['-I../src',
-           '-I../src/backends',
-           '-I../src/engines',
-           '-I../src/utilities',
-           '-I../src/third-party',
-           '-I../src/third-party/headers']
+include = [os.path.abspath('../src'),
+           os.path.abspath('../src/backends'),
+           os.path.abspath('../src/engines'),
+           os.path.abspath('../src/utilities'),
+           os.path.abspath('../src/third-party'),
+           os.path.abspath('../src/third-party/headers')]
 warnings = ['-pedantic', '-Wall', '-Wextra', '-Wfloat-equal', '-Wundef',
             '-Wcast-align', '-Wwrite-strings', '-Wmissing-declarations',
             '-Wshadow', '-Woverloaded-virtual']
 opt = ['-ffast-math', '-O3', '-march=native']
-extra_compile_args = ['-g', '-std=c++11'] + opt + include + warnings
+if sys.platform != 'win32':
+    extra_compile_args = ['-g', '-std=c++11'] + opt + warnings
+else:
+    extra_compile_args = ['/W1', '/Ox']
+
 extra_link_args = []
 libraries = []
 library_dirs = []
-include_dirs = []
+include_dirs = include
 
 # Numpy BLAS
 blas_info = np_config('blas_mkl_info')
@@ -34,7 +38,6 @@ include_dirs += blas_info.get('include_dirs', [])
 
 # MacOS Specific build instructions
 if sys.platform == 'darwin':
-
     # Set minimum os version to support C++11 headers
     min_macos_version = '-mmacosx-version-min=10.9'
     extra_compile_args.append(min_macos_version)
@@ -50,8 +53,10 @@ if sys.platform == 'darwin':
             extra_compile_args.append('-fopenmp')
             extra_link_args.append('-fopenmp')
             break
+elif sys.platform == 'win32':
+    extra_compile_args.append('/openmp')
 else:
-    # Linux and Windows
+    # Linux
     extra_compile_args.append('-fopenmp')
     extra_link_args.append('-fopenmp')
 

--- a/src/qasm-simulator-cpp/cython-build-example/example_setup.py
+++ b/src/qasm-simulator-cpp/cython-build-example/example_setup.py
@@ -60,6 +60,12 @@ else:
     extra_compile_args.append('-fopenmp')
     extra_link_args.append('-fopenmp')
 
+# Remove -Wstrict-prototypes from cflags
+import distutils.sysconfig
+cfg_vars = distutils.sysconfig.get_config_vars()
+if "CFLAGS" in cfg_vars:
+    cfg_vars["CFLAGS"] = cfg_vars["CFLAGS"].replace("-Wstrict-prototypes", "")
+
 # Simulator extension
 qasm_simulator = Extension('qasm_simulator',
                            sources=['qasm_simulator.pyx'],

--- a/src/qasm-simulator-cpp/cython-build-example/example_simulation.py
+++ b/src/qasm-simulator-cpp/cython-build-example/example_simulation.py
@@ -1,0 +1,155 @@
+import numpy as np
+import json
+from qasm_simulator import SimulatorWrapper
+
+
+class SimulatorEncoder(json.JSONEncoder):
+    """
+    JSON encoder for NumPy arrays and complex numbers.
+
+    This functions as the standard JSON Encoder but adds support
+    for encoding:
+        complex numbers z as lists [z.real, z.imag]
+        ndarrays as nested lists.
+    """
+    def default(self, obj):
+        if isinstance(obj, np.ndarray):
+            return obj.tolist()
+        if isinstance(obj, complex):
+            return [obj.real, obj.imag]
+        return json.JSONEncoder.default(self, obj)
+
+
+class SimulatorDecoder(json.JSONDecoder):
+    """
+    JSON decoder for the output from C++ qasm_simulator.
+
+    This converts complex vectors and matrices into numpy arrays
+    for the following keys.
+    """
+    def __init__(self, *args, **kwargs):
+        json.JSONDecoder.__init__(self, object_hook=self.object_hook, *args, **kwargs)
+
+    def object_hook(self, obj):
+        for key in ['U_error', 'density_matrix']:
+            # JSON is a complex matrix
+            if key in obj:
+                tmp = np.array(obj[key])
+                obj[key] = tmp[::, ::, 0] + 1j * tmp[::, ::, 1]
+        for key in ['quantum_state', 'inner_products']:
+            # JSON is a list of complex vectors
+            if key in obj:
+                for j in range(len(obj[key])):
+                    tmp = np.array(obj[key][j])
+                    obj[key][j] = tmp[::, 0] + 1j * tmp[::, 1]
+        return obj
+
+
+def cpp_run(qobj_dict):
+    """
+    Execute a qobj dictionary on the C++ QASM simulator.
+
+    Args:
+        qobj (dict): a python dictionary qobj.
+
+    Returns:
+        result (dict): the simulator output.
+
+    Note that this will serialize complex Numpy arrays into valid JSON
+    and deserialize corresponding json back into complex Numpy arrays.
+    """
+    simulator = SimulatorWrapper()
+    result = simulator.run(json.dumps(qobj_dict, cls=SimulatorEncoder))
+    return json.loads(result, cls=SimulatorDecoder)
+
+
+# Example qobj
+qobj = {
+    "id": "cython_test",
+    "config": {
+        "shots": 1000,
+        "seed": 1,
+        "backend": "local_qasm_simulator_cpp"
+    },
+    "circuits": [
+        {
+            "name": "bell measure",
+            "compiled_circuit": {
+                "header": {
+                    "clbit_labels": [["c", 2]],
+                    "number_of_clbits": 2,
+                    "number_of_qubits": 2,
+                    "qubit_labels": [["q", 0], ["q", 1]]
+                },
+                "operations": [
+                    {"name": "h", "qubits": [0]},
+                    {"name": "cx", "qubits": [0, 1]},
+                    {"name": "snapshot", "params": [0]},
+                    {"name": "measure", "qubits": [0], "clbits": [0]},
+                    {"name": "measure", "qubits": [1], "clbits": [1]}
+                ]
+            }
+        },
+        {
+            "name": "bell measure",
+            "config": {
+                "noise_params": {
+                    "CX": {"p_pauli": [0.1 / 16 for _ in range(15)]},
+                    "X90": {"p_pauli": [0.01 / 4 for _ in range(3)]}
+                }
+            },
+            "compiled_circuit": {
+                "header": {
+                    "clbit_labels": [["c", 2]],
+                    "number_of_clbits": 2,
+                    "number_of_qubits": 2,
+                    "qubit_labels": [["q", 0], ["q", 1]]
+                },
+                "operations": [
+                    {"name": "h", "qubits": [0]},
+                    {"name": "cx", "qubits": [0, 1]},
+                    {"name": "measure", "qubits": [0], "clbits": [0]},
+                    {"name": "measure", "qubits": [1], "clbits": [1]}
+                ]
+            }
+        }
+    ]
+}
+
+qobj_bad = {
+    "id": "cython_test",
+    "config": {
+        "shots": 1000,
+        "seed": 1,
+        "backend": "local_qasm_simulator_cpp"
+    },
+    "circuits": [
+        {
+            "name": "bell measure",
+            "compiled_circuit": {
+                "header": {
+                    "clbit_labels": [["c", 2]],
+                    "number_of_clbits": 2,
+                    "number_of_qubits": 2,
+                    "qubit_labels": [["q", 0], ["q", 1]]
+                },
+                "operations": [
+                    {"name": "h", "qubits": [0]},
+                    {"name": "cx", "qubits": [0, 2]},
+                    {"name": "snapshot", "params": [0]},
+                    {"name": "measure", "qubits": [0], "clbits": [0]},
+                    {"name": "measure", "qubits": [1], "clbits": [1]}
+                ]
+            }
+        }
+    ]
+}
+
+# Execute and print result
+print('TESTING CORRECT QOBJ:\n')
+result = cpp_run(qobj)
+print(result)
+
+print('\nTESTING QOBJ WHICH SHOULD RAISE AN EXCEPTION:\n')
+result_bad = cpp_run(qobj_bad)
+print(result_bad)

--- a/src/qasm-simulator-cpp/cython-build-example/qasm_simulator.pyx
+++ b/src/qasm-simulator-cpp/cython-build-example/qasm_simulator.pyx
@@ -1,0 +1,43 @@
+from libcpp.string cimport string
+
+# Link against SciPy BLAS functions
+from scipy.linalg.cython_blas cimport sgemv, dgemv, cgemv, zgemv
+from scipy.linalg.cython_blas cimport sgemm, dgemm, cgemm, zgemm
+
+# Import C++ Simulator class
+cdef extern from "simulator.hpp" namespace "QISKIT":
+
+    cdef cppclass Simulator:
+        Simulator() except +
+        string execute(int indent) except +
+        void load_qobj_string(string qobj) except +
+
+
+cdef class SimulatorWrapper:
+    """
+    Python wrapper of C++ Simulator class.
+
+    Methods:
+        run: executes a qobj.
+    """
+    cdef Simulator *thisptr
+
+    def __cinit__(self):
+        self.thisptr = new Simulator()
+
+    def __dealloc__(self):
+        del self.thisptr
+
+    def run(self, qobj_str):
+        """
+        Execute a qobj
+
+        Args:
+            qobj_str (str): a qobj JSON serialized as a python string.
+
+        Returns:
+            result JSON serialized as a python string.
+        """
+        # serialize qobj as json byte string
+        self.thisptr.load_qobj_string(qobj_str.encode())
+        return self.thisptr.execute(-1).decode()


### PR DESCRIPTION
Example of building and linking the C++ simulator using cython. Based on PR #386

## Description

Adds an `cython-build-example` folder into the qasm-simulator-cpp folder which contains an `example_setup.py` script for building and wrapping the simulator using cython, and an `example_simulation.py` for running the simulator.

This can be run using
```
cd src/qasm_simulator_cpp/cython-build-example
python example_setup.py build_ext --inplace
python example_simulation.py
```

## Motivation and Context

This allows cross platform building of the simulator by linking to the BLAS libraries already used by Numpy (such as MLK if python is installed with Anaconda).
It allows calling as a native python class without needing to use subprocess, and forwards C++ exceptions to python exceptions.

## How Has This Been Tested?
- It has been tested with a simple example script
- The build has been tested on MacOS 10.13 building with xcode developer tools, homebrew gcc-7, and linking against anaconda MKL or apple accelerate framework, on Windows 10 using MSVC 2015 and anaconda MKL, on Ubuntu 16.04 using GCC 5 and anaconda MKL. 

