### PR TITLE
Least busy filter, plus other tweaks to backends

### DIFF
--- a/examples/python/hello_quantum.py
+++ b/examples/python/hello_quantum.py
@@ -7,7 +7,7 @@ used `pip install`, the examples only work from the root directory.
 
 # Import the QISKit
 import qiskit
-from qiskit.wrapper import available_backends, execute, register
+from qiskit.wrapper import available_backends, execute, register, least_busy
 
 # Authenticate for access to remote backends
 try:
@@ -18,17 +18,6 @@ except:
              Have you initialized a Qconfig.py file with your personal token?
              For now, there's only access to local simulator backends...""")
 
-
-def lowest_pending_jobs():
-    """Returns the backend with lowest pending jobs."""
-    list_of_backends = qiskit.wrapper.available_backends(
-        {'local': False, 'simulator': False})
-    device_status = [qiskit.wrapper.get_backend(backend).status
-                     for backend in list_of_backends]
-
-    best = min([x for x in device_status if x['available'] is True],
-               key=lambda x: x['pending_jobs'])
-    return best['name']
 
 try:
     # Create a Quantum Register with 2 qubits.
@@ -63,7 +52,7 @@ try:
     # Compile and run the Quantum Program on a real device backend
     #try:
     if remote_backends:
-        best_device = lowest_pending_jobs()
+        best_device = least_busy(available_backends())
         print("Running on current least busy device: ", best_device)
 
         #runing the job

--- a/examples/python/using_qiskit_core_level_1.py
+++ b/examples/python/using_qiskit_core_level_1.py
@@ -38,18 +38,6 @@ except:
              For now, there's only access to local simulator backends...""")
 
 
-def lowest_pending_jobs():
-    """Returns the backend with lowest pending jobs."""
-    list_of_backends = qiskit.wrapper.available_backends(
-        {'local': False, 'simulator': False})
-    device_status = [qiskit.wrapper.get_backend(backend).status
-                     for backend in list_of_backends]
-
-    best = min([x for x in device_status if x['available'] is True],
-               key=lambda x: x['pending_jobs'])
-    return best['name']
-
-
 try:
     # Create a Quantum and Classical Register and giving a name.
     qubit_reg = qiskit.QuantumRegister(2, name='q')
@@ -113,7 +101,7 @@ try:
             s = backend.status
 
         # select least busy available device and execute.
-        best_device = lowest_pending_jobs()
+        best_device = least_busy(qiskit.wrapper.available_backends({'local': False}))
         print("Running on current least busy device: ", best_device)
 
         my_backend = qiskit.wrapper.get_backend(best_device)

--- a/qiskit/_quantumprogram.py
+++ b/qiskit/_quantumprogram.py
@@ -685,7 +685,7 @@ class QuantumProgram(object):
             "Using the API object instead is recommended.", DeprecationWarning)
         qiskit.wrapper.register(token, url,
                                 hub, group, project, proxies, verify,
-                                provider_name='qiskit')
+                                provider_name='ibmq')
 
         # TODO: the setting of self._api and self.__api_config is left for
         # backwards-compatibility.

--- a/qiskit/backends/basebackend.py
+++ b/qiskit/backends/basebackend.py
@@ -69,10 +69,10 @@ class BaseBackend(ABC):
         backend_name = self.configuration.get('name', '')
         return {'name': backend_name, 'available': True}
 
-    def __str__(self):
+    def __repr__(self):
         backend_name = self.configuration.get('name')
         if backend_name:
             # TODO: remove this conditional when we are able to enforce
             # that all backends have a configuration['name'] more forcefully
             return str(backend_name)
-        return super().__str__()
+        return super().__repr__()

--- a/qiskit/backends/ibmq/__init__.py
+++ b/qiskit/backends/ibmq/__init__.py
@@ -18,4 +18,5 @@
 """Backends provided by IBM Quantum Experience."""
 
 from .ibmqprovider import IBMQProvider
+from .ibmqprovider import least_busy
 from .ibmqbackend import IBMQBackend

--- a/qiskit/backends/ibmq/__init__.py
+++ b/qiskit/backends/ibmq/__init__.py
@@ -18,5 +18,4 @@
 """Backends provided by IBM Quantum Experience."""
 
 from .ibmqprovider import IBMQProvider
-from .ibmqprovider import least_busy
 from .ibmqbackend import IBMQBackend

--- a/qiskit/backends/ibmq/ibmqprovider.py
+++ b/qiskit/backends/ibmq/ibmqprovider.py
@@ -55,6 +55,9 @@ class IBMQProvider(BaseProvider):
 
         Returns:
             list[IBMQBackend]: available backends from this provider (after filtering)
+        
+        Raises:
+            QISKitError: if filter(s) is neither dict nor callable
         """
         # pylint: disable=arguments-differ
         backends = self.backends
@@ -74,7 +77,7 @@ class IBMQProvider(BaseProvider):
                 # acceptor filter: accept or reject a specific backend
                 # e.g. lambda x: x.configuration['n_qubits'] > 5
                 backends = {name: instance for name, instance in backends.items()
-                            if filter_(instance) == True}
+                            if filter_(instance) is True}
             else:
                 raise QISKitError('backend filters must be either dict or callable.')
 

--- a/qiskit/backends/ibmq/ibmqprovider.py
+++ b/qiskit/backends/ibmq/ibmqprovider.py
@@ -26,7 +26,7 @@ from qiskit import QISKitError
 
 class IBMQProvider(BaseProvider):
     """Provider for remote IbmQ backends."""
-    def __init__(self, token, url,
+    def __init__(self, token, url='https://quantumexperience.ng.bluemix.net/api',
                  hub=None, group=None, project=None, proxies=None, verify=True):
         super().__init__()
 

--- a/qiskit/backends/local/localprovider.py
+++ b/qiskit/backends/local/localprovider.py
@@ -60,7 +60,7 @@ class LocalProvider(BaseProvider):
         Returns:
             list[BaseBackend]: a list of backend names available from all the
                 providers.
-        """        
+        """
         # pylint: disable=arguments-differ
         backends = self.backends
 

--- a/qiskit/backends/local/localprovider.py
+++ b/qiskit/backends/local/localprovider.py
@@ -54,13 +54,24 @@ class LocalProvider(BaseProvider):
         return self.backends[name]
 
     def available_backends(self, filters=None):
+        """
+        Args:
+            filters (dict): dictionary of filtering conditions.
+        Returns:
+            list[BaseBackend]: a list of backend names available from all the
+                providers.
+        """        
         # pylint: disable=arguments-differ
         backends = self.backends
 
-        filters = filters or {}
-        for key, value in filters.items():
-            backends = {name: instance for name, instance in backends.items()
-                        if instance.configuration.get(key) == value}
+        if isinstance(filters, dict):
+            filters = [filters]
+
+        for filter_ in filters:
+            if isinstance(filter_, dict):
+                for key, value in filter_.items():
+                    backends = {name: instance for name, instance in backends.items()
+                                if instance.configuration.get(key) == value}
         return list(backends.values())
 
     @classmethod

--- a/qiskit/wrapper/__init__.py
+++ b/qiskit/wrapper/__init__.py
@@ -24,4 +24,4 @@ refer to the documentation of each component and use them separately.
 """
 
 from ._wrapper import (available_backends, local_backends, remote_backends,
-                       get_backend, compile, execute, register)
+                       least_busy, get_backend, compile, execute, register)

--- a/qiskit/wrapper/_wrapper.py
+++ b/qiskit/wrapper/_wrapper.py
@@ -26,7 +26,7 @@ from qiskit.wrapper.defaultqiskitprovider import DefaultQISKitProvider
 _DEFAULT_PROVIDER = DefaultQISKitProvider()
 
 
-def register(token, url=None,
+def register(token, url='https://quantumexperience.ng.bluemix.net/api',
              hub=None, group=None, project=None, proxies=None, verify=True,
              provider_name='ibmq'):
     """
@@ -49,10 +49,8 @@ def register(token, url=None,
         QISKitError: if the provider name is not recognized.
     """
     if provider_name == 'ibmq':
-        provider = IBMQProvider(token=token,
-                                url='https://quantumexperience.ng.bluemix.net/api',
-                                hub=hub, group=group, project=project,
-                                proxies=proxies, verify=verify)
+        provider = IBMQProvider(token, url,
+                                hub, group, project, proxies, verify)
         _DEFAULT_PROVIDER.add_provider(provider)
     else:
         raise QISKitError('provider name %s is not recognized' % provider_name)

--- a/qiskit/wrapper/_wrapper.py
+++ b/qiskit/wrapper/_wrapper.py
@@ -28,7 +28,7 @@ _DEFAULT_PROVIDER = DefaultQISKitProvider()
 
 def register(token, url=None,
              hub=None, group=None, project=None, proxies=None, verify=True,
-             provider_name='qiskit'):
+             provider_name='ibmq'):
     """
     Authenticate against an online backend provider.
 
@@ -44,13 +44,12 @@ def register(token, url=None,
                 'urls' and credential keys.
             verify (bool): If False, ignores SSL certificates errors.
             provider_name (str): the unique name for the online backend
-                provider (for example, 'qiskit' for the IBM Quantum Experience).
+                provider (for example, 'ibmq' for the IBM Quantum Experience).
     Raises:
         QISKitError: if the provider name is not recognized.
     """
-    if provider_name == 'qiskit':
-        provider = IBMQProvider(token,
-                                url='https://quantumexperience.ng.bluemix.net/api',
+    if provider_name == 'ibmq':
+        provider = IBMQProvider(token, url,
                                 hub, group, project, proxies, verify)
         _DEFAULT_PROVIDER.add_provider(provider)
     else:

--- a/qiskit/wrapper/_wrapper.py
+++ b/qiskit/wrapper/_wrapper.py
@@ -26,7 +26,7 @@ from qiskit.wrapper.defaultqiskitprovider import DefaultQISKitProvider
 _DEFAULT_PROVIDER = DefaultQISKitProvider()
 
 
-def register(token, url,
+def register(token, url=None,
              hub=None, group=None, project=None, proxies=None, verify=True,
              provider_name='qiskit'):
     """
@@ -49,7 +49,8 @@ def register(token, url,
         QISKitError: if the provider name is not recognized.
     """
     if provider_name == 'qiskit':
-        provider = IBMQProvider(token, url,
+        provider = IBMQProvider(token,
+                                url='https://quantumexperience.ng.bluemix.net/api',
                                 hub, group, project, proxies, verify)
         _DEFAULT_PROVIDER.add_provider(provider)
     else:

--- a/qiskit/wrapper/_wrapper.py
+++ b/qiskit/wrapper/_wrapper.py
@@ -49,8 +49,10 @@ def register(token, url=None,
         QISKitError: if the provider name is not recognized.
     """
     if provider_name == 'ibmq':
-        provider = IBMQProvider(token, 'https://quantumexperience.ng.bluemix.net/api',
-                                hub, group, project, proxies, verify)
+        provider = IBMQProvider(token=token,
+                                url='https://quantumexperience.ng.bluemix.net/api',
+                                hub=hub, group=group, project=project,
+                                proxies=proxies, verify=verify)
         _DEFAULT_PROVIDER.add_provider(provider)
     else:
         raise QISKitError('provider name %s is not recognized' % provider_name)
@@ -98,8 +100,8 @@ def remote_backends():
 
 def least_busy(names):
     """
-    Return the least busy available backend for those that 
-    have a `pending_jobs` in their `status`. Backends such as 
+    Return the least busy available backend for those that
+    have a `pending_jobs` in their `status`. Backends such as
     local backends that do not have this are ignored.
 
     Args:

--- a/qiskit/wrapper/_wrapper.py
+++ b/qiskit/wrapper/_wrapper.py
@@ -49,7 +49,7 @@ def register(token, url=None,
         QISKitError: if the provider name is not recognized.
     """
     if provider_name == 'ibmq':
-        provider = IBMQProvider(token, url,
+        provider = IBMQProvider(token, 'https://quantumexperience.ng.bluemix.net/api',
                                 hub, group, project, proxies, verify)
         _DEFAULT_PROVIDER.add_provider(provider)
     else:
@@ -58,7 +58,7 @@ def register(token, url=None,
 # Functions for inspecting and retrieving backends.
 
 
-def available_backends(filters=None):
+def available_backends(*filters):
     """
     Return the backends that are available in the SDK, optionally filtering
     them based on their capabilities.
@@ -68,7 +68,7 @@ def available_backends(filters=None):
         an online backend provider needs to be established by calling the
         `register()` function.
     Args:
-        filters (dict): dictionary of filtering conditions.
+        *filters (dict or callable): filtering conditions.
     Returns:
         list[str]: the names of the available backends.
     """
@@ -94,6 +94,25 @@ def remote_backends():
         list[str]: the names of the available remote backends.
     """
     return available_backends({'local': False})
+
+
+def least_busy(names):
+    """
+    Return the least busy available backend for those that 
+    have a `pending_jobs` in their `status`. Backends such as 
+    local backends that do not have this are ignored.
+
+    Args:
+        names(str): backend names to choose from
+    Returns:
+        str: the name of the least busy backend
+    """
+    backends = [get_backend(name) for name in names]
+    try:
+        return min([b for b in backends if b.status['available'] and 'pending_jobs' in b.status],
+                   key=lambda b: b.status['pending_jobs'])
+    except (ValueError, TypeError):
+        assert False, "Error: can only find least_busy backend from a non-empty list."
 
 
 def get_backend(name):

--- a/qiskit/wrapper/defaultqiskitprovider.py
+++ b/qiskit/wrapper/defaultqiskitprovider.py
@@ -45,7 +45,7 @@ class DefaultQISKitProvider(BaseProvider):
     def available_backends(self, filters=None):
         """
         Args:
-            filters (dict): dictionary of filtering conditions.
+            filters (dict or callable): filtering conditions.
         Returns:
             list[BaseBackend]: a list of backend names available from all the
                 providers.
@@ -59,7 +59,7 @@ class DefaultQISKitProvider(BaseProvider):
 
     def add_provider(self, provider):
         """
-        Add a new provider to the list of know providers.
+        Add a new provider to the list of known providers.
 
         Args:
             provider (BaseProvider): Provider instance.

--- a/test/python/test_backends.py
+++ b/test/python/test_backends.py
@@ -210,7 +210,7 @@ class TestBackends(QiskitTestCase):
     @requires_qe_access
     def test_wrapper_register_ok(self, QE_TOKEN, QE_URL):
         """Test wrapper.register()."""
-        qiskit.wrapper.register(QE_TOKEN, QE_URL, provider_name='qiskit')
+        qiskit.wrapper.register(QE_TOKEN, QE_URL, provider_name='ibmq')
         backends = qiskit.wrapper.available_backends()
         self.log.info(backends)
         self.assertTrue(len(backends) > 0)
@@ -218,7 +218,7 @@ class TestBackends(QiskitTestCase):
     @requires_qe_access
     def test_wrapper_available_backends_with_filter(self, QE_TOKEN, QE_URL):
         """Test wrapper.available_backends(filter=...)."""
-        qiskit.wrapper.register(QE_TOKEN, QE_URL, provider_name='qiskit')
+        qiskit.wrapper.register(QE_TOKEN, QE_URL, provider_name='ibmq')
         backends = qiskit.wrapper.available_backends({'local': False, 'simulator': True})
         self.log.info(backends)
         self.assertTrue(len(backends) > 0)

--- a/test/python/test_compiler.py
+++ b/test/python/test_compiler.py
@@ -24,15 +24,9 @@ import qiskit._compiler
 from qiskit import Result
 from qiskit.backends.local import QasmSimulator
 from qiskit.backends.ibmq import IBMQProvider
+from qiskit import wrapper
 
 from .common import requires_qe_access, QiskitTestCase
-
-
-def lowest_pending_jobs(list_of_backends):
-    """Returns the backend with lowest pending jobs."""
-    by_pending_jobs = sorted(list_of_backends,
-                             key=lambda x: x.status['pending_jobs'])
-    return by_pending_jobs[0]
 
 
 class TestCompiler(QiskitTestCase):
@@ -155,11 +149,12 @@ class TestCompiler(QiskitTestCase):
     def test_compile_remote(self, QE_TOKEN, QE_URL):
         """Test Compiler remote.
 
-        If all correct some should exists.
+        If all correct some should exist.
         """
         provider = IBMQProvider(QE_TOKEN, QE_URL)
-        my_backend = lowest_pending_jobs(
-            provider.available_backends({'local': False, 'simulator': False}))
+        devices = provider.available_backends({'local': False, 'simulator': False})
+        my_backend = wrapper.least_busy([d.configuration['name'] for d in devices])
+        my_backend = provider.get_backend(my_backend)
 
         qubit_reg = qiskit.QuantumRegister(2, name='q')
         clbit_reg = qiskit.ClassicalRegister(2, name='c')
@@ -177,11 +172,12 @@ class TestCompiler(QiskitTestCase):
     def test_compile_two_remote(self, QE_TOKEN, QE_URL):
         """Test Compiler remote on two circuits.
 
-        If all correct some should exists.
+        If all correct some should exist.
         """
         provider = IBMQProvider(QE_TOKEN, QE_URL)
-        my_backend = lowest_pending_jobs(
-            provider.available_backends({'local': False, 'simulator': False}))
+        devices = provider.available_backends({'local': False, 'simulator': False})
+        my_backend = wrapper.least_busy([d.configuration['name'] for d in devices])
+        my_backend = provider.get_backend(my_backend)
 
         qubit_reg = qiskit.QuantumRegister(2, name='q')
         clbit_reg = qiskit.ClassicalRegister(2, name='c')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR does the following things:
1- Replaces the `__str__` method by the `__repr__` method in the backend, since a list of backends does not print correctly otherwise.
2- Passes the default quantum experience url to the `_wrapper.register` method, to make it easier to register just by your token.
3- Changes the ibmq provider name from `qiskit` to `ibmq`.
4- Adds the ability to filter ibmq backends by passing both dict filters and function filters. In particular, the least busy filter resolves #404 and [issue 104 of the tutorials](https://github.com/QISKit/qiskit-tutorial/issues/104).

See examples below:

```python
import Qconfig
from qiskit.backends.ibmq import IBMQProvider, least_busy
ibmq_provider = IBMQProvider(Qconfig.APItoken)
filter_1 = {'n_qubits': 5, 'local': False}
filter_2 = lambda x: x.configuration['n_qubits'] > 5
filter_3 = lambda x: x.configuration['simulator'] == False and x.configuration['n_qubits'] > 5
filter_4 = lambda x: x.status['available']
filter_5 = least_busy
ibmq_provider.available_backends(filter_2)
```

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.