### PR TITLE
[WIP] Qobj class, schema validation, and update backends to accept qobj

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -297,7 +297,7 @@ ignored-classes=optparse.Values,thread._local,_thread._local
 # List of members which are set dynamically and missed by pylint inference
 # system, and so shouldn't trigger E1101 when accessed. Python regular
 # expressions are accepted.
-generated-members=self.circuit.*,qcs.h,qc1.h,qc2.cx,qc.h,self.u1,self.cx,self.ccx,trial_circuit
+generated-members=self.circuit.*,qcs.h,qc1.h,qc2.cx,qc.h,self.u1,self.cx,self.ccx,trial_circuit,qc.x,qc1.x
 # self.circuit.*: false positives when self.circuit == QuantumCircuit, as it
 # provides a "__getitem__" dynamic method and gate definition is dynamic.
 # For qiskit.extensions.standard, self.foo is also needed.

--- a/qiskit/_jobprocessor.py
+++ b/qiskit/_jobprocessor.py
@@ -22,7 +22,6 @@ from concurrent import futures
 from threading import Lock
 
 from ._qiskiterror import QISKitError
-from ._compiler import compile_circuit
 from ._result import Result
 
 logger = logging.getLogger(__name__)
@@ -45,19 +44,15 @@ def run_backend(q_job):
     """
     backend = q_job.backend
     qobj = q_job.qobj
-    backend_name = qobj['config']['backend_name']
+    backend_name = qobj.header.backend_name
+
     if not backend:
         raise QISKitError("No backend instance to run on.")
     if backend_name != backend.configuration['name']:
         raise QISKitError('non-matching backends specified in Qobj '
                           'object and json')
-    if backend.configuration.get('local'):  # remove condition when api gets qobj
-        for circuit in qobj['circuits']:
-            if circuit['compiled_circuit'] is None:
-                compiled_circuit = compile_circuit(circuit['circuit'], format='json')
-                circuit['compiled_circuit'] = compiled_circuit
 
-    return backend.run(q_job)
+    return backend.run(qobj)
 
 
 class JobProcessor:

--- a/qiskit/_jobprocessor.py
+++ b/qiskit/_jobprocessor.py
@@ -31,6 +31,9 @@ logger = logging.getLogger(__name__)
 def run_backend(q_job):
     """Run a program of compiled quantum circuits on a backend.
 
+    TODO: replace with run_backend(qobj: Qobj)
+    TODO: backend.run(qobj.as_dict())
+
     Args:
         q_job (QuantumJob): job object
 
@@ -63,6 +66,8 @@ class JobProcessor:
     """
     def __init__(self, q_jobs, callback, max_workers=1):
         """
+        TODO: replace with __init__(q_jobs: list[Qobj])
+
         Args:
             q_jobs (list(QuantumJob)): List of QuantumJob objects.
             callback (fn(results)): The function that will be called when all

--- a/qiskit/_quantumjob.py
+++ b/qiskit/_quantumjob.py
@@ -28,6 +28,8 @@ from .qasm import Qasm
 from .unroll import Unroller, DagUnroller, JsonBackend
 from .dagcircuit import DAGCircuit
 
+# TODO: remove the file after Qobj is completed
+
 
 class QuantumJob():
     """Creates a quantum circuit job."""

--- a/qiskit/_quantumprogram.py
+++ b/qiskit/_quantumprogram.py
@@ -1230,10 +1230,15 @@ class QuantumProgram(object):
     def _run_internal(self, qobj_list, wait=5, timeout=60, callback=None):
         q_job_list = []
         for qobj in qobj_list:
-            backend = qiskit.wrapper.get_backend(qobj['config']['backend_name'])
-            q_job = QuantumJob(qobj, backend=backend, preformatted=True, resources={
-                'max_credits': qobj['config']['max_credits'], 'wait': wait,
-                'timeout': timeout})
+            # TODO: qobj.header.backend is the backend it was compiled to, not
+            # the one to be executed in.
+            backend = qiskit.wrapper.get_backend(qobj.header.backend_name)
+            q_job = QuantumJob(
+                qobj, backend=backend, preformatted=True,
+                resources={
+                    'max_credits': qobj.config.max_credits,
+                    'wait': wait,
+                    'timeout': timeout})
             q_job_list.append(q_job)
 
         job_processor = JobProcessor(q_job_list, max_workers=5,

--- a/qiskit/_result.py
+++ b/qiskit/_result.py
@@ -93,7 +93,7 @@ class Result(object):
             if isinstance(self._qobj['id'], str):
                 self._qobj['id'] = [self._qobj['id']]
             self._qobj['id'].append(other._qobj['id'])
-            self._qobj['circuits'] += other._qobj['circuits']
+            self._qobj['experiments'] += other._qobj['experiments']
             self._result['result'] += other._result['result']
             return self
         else:
@@ -161,9 +161,9 @@ class Result(object):
         """
         try:
             qobj = self._qobj
-            for index in range(len(qobj["circuits"])):
-                if qobj["circuits"][index]['name'] == name:
-                    return qobj["circuits"][index]["compiled_circuit_qasm"]
+            for index in range(len(qobj["experiments"])):
+                if qobj["experiments"][index]['name'] == name:
+                    return qobj["experiments"][index]["compiled_circuit_qasm"]
         except KeyError:
             pass
         raise QISKitError('No  qasm for circuit "{0}"'.format(name))
@@ -217,7 +217,7 @@ class Result(object):
             circuit_name = circuit_name.name
 
         if circuit_name is None:
-            circuits = list([i['name'] for i in self._qobj['circuits']])
+            circuits = list([i['name'] for i in self._qobj['experiments']])
             if len(circuits) == 1:
                 circuit_name = circuits[0]
             else:
@@ -226,8 +226,8 @@ class Result(object):
 
         try:
             qobj = self._qobj
-            for index in range(len(qobj['circuits'])):
-                if qobj['circuits'][index]['name'] == circuit_name:
+            for index in range(len(qobj['experiments'])):
+                if qobj['experiments'][index]['name'] == circuit_name:
                     return self._result['result'][index]['data']
         except (KeyError, TypeError):
             pass
@@ -261,7 +261,7 @@ class Result(object):
         Returns:
             List: A list of circuit names.
         """
-        return [c['name'] for c in self._qobj['circuits']]
+        return [c['name'] for c in self._qobj['experiments']]
 
     def average_data(self, name, observable):
         """Compute the mean value of an diagonal observable.
@@ -299,9 +299,9 @@ class Result(object):
             qubit_pol: mxn double array where m is the number of circuit, n the number of qubits
             xvals: mx1 array of the circuit xvals
         """
-        ncircuits = len(self._qobj['circuits'])
+        ncircuits = len(self._qobj['experiments'])
         # Is this the best way to get the number of qubits?
-        nqubits = self._qobj['circuits'][0]['compiled_circuit']['header']['number_of_qubits']
+        nqubits = self._qobj['experiments'][0]['compiled_circuit']['header']['number_of_qubits']
         qubitpol = numpy.zeros([ncircuits, nqubits], dtype=float)
         xvals = numpy.zeros([ncircuits], dtype=float)
 
@@ -318,9 +318,9 @@ class Result(object):
         # go through each circuit and for eqch qubit and apply the operators using "average_data"
         for circuit_ind in range(ncircuits):
             if xvals_dict:
-                xvals[circuit_ind] = xvals_dict[self._qobj['circuits'][circuit_ind]['name']]
+                xvals[circuit_ind] = xvals_dict[self._qobj['experiments'][circuit_ind]['name']]
             for qubit_ind in range(nqubits):
                 qubitpol[circuit_ind, qubit_ind] = self.average_data(
-                    self._qobj['circuits'][circuit_ind]['name'], z_dicts[qubit_ind])
+                    self._qobj['experiments'][circuit_ind]['name'], z_dicts[qubit_ind])
 
         return qubitpol, xvals

--- a/qiskit/backends/local/qasm_simulator_cpp.py
+++ b/qiskit/backends/local/qasm_simulator_cpp.py
@@ -81,9 +81,17 @@ class QasmSimulatorCpp(BaseBackend):
 
     def run(self, q_job):
         """Run a QuantumJob on the the backend."""
+        # TODO: replace with run(self, qobj: Qobj)
         qobj = q_job.qobj
         result = run(qobj, self._configuration['exe'])
         return Result(result, qobj)
+
+    def _validate_qobj(self, qobj):
+        """Validate qobj against backend specific schema.
+        Validate qobj against any other semantic constraints imposed by this backend.
+        """
+        # TODO: invoke when Qobj is completed.
+        pass
 
 
 class CliffordCppSimulator(BaseBackend):
@@ -119,6 +127,7 @@ class CliffordCppSimulator(BaseBackend):
 
     def run(self, q_job):
         """Run a QuantumJob on the the backend."""
+        # TODO: replace with run(self, qobj: Qobj)
         qobj = q_job.qobj
         # set backend to Clifford simulator
         if 'config' in qobj:

--- a/qiskit/backends/local/qasmsimulator.py
+++ b/qiskit/backends/local/qasmsimulator.py
@@ -285,6 +285,8 @@ class QasmSimulator(BaseBackend):
 
     def run(self, qobj):
         """Run circuits in q_job"""
+        # pylint: disable=arguments-differ
+        # TODO: revise arguments in base class
         # Generating a string id for the job
         job_id = str(uuid.uuid4())
         result_list = []

--- a/qiskit/qobj/__init__.py
+++ b/qiskit/qobj/__init__.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2018 IBM RESEARCH. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =============================================================================
+
+"""Module for the QObj structure."""
+
+from ._qobj import (QObj, QObjConfig, QObjExperiment, QObjInstruction,
+                    QObjStructure)

--- a/qiskit/qobj/_qobj.py
+++ b/qiskit/qobj/_qobj.py
@@ -1,0 +1,105 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2018 IBM RESEARCH. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =============================================================================
+
+"""Models for QObj and its related components."""
+
+from ._utils import QObjType
+
+
+class QObjStructure(object):
+    """
+    General QObj structure.
+    """
+    def __init__(self, **kwargs):
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
+
+class QObj(QObjStructure):
+    """Representation of a QObj.
+
+    Attributes:
+        id (str): QObj identifier.
+        config (QObjConfig): config settings for the QObj.
+        experiments (list[QObjExperiment]): list of experiments.
+        headers (QObjStructure): headers.
+        type (str): experiment type (QASM/PULSE).
+    """
+    def __init__(self, id, config, experiments, headers, **kwargs):
+        # pylint: disable=redefined-builtin,invalid-name
+        self.id = id
+        self.config = config
+        self.experiments = experiments
+        self.headers = headers
+        self.type = QObjType.PULSE.value
+
+        super().__init__(**kwargs)
+
+    def as_dict(self):
+        """
+        Returns:
+            dict: a dictionary representation of the QObj.
+        """
+        return {
+            'id': self.id,
+            'config': self.config.as_dict(),
+            'experiments': [experiment.as_dict() for experiment
+                            in self.experiments],
+            'headers': self.headers.as_dict()
+        }
+
+
+class QObjConfig(QObjStructure):
+    """Configuration for a QObj.
+
+    Attributes:
+        shots (int): number of shots.
+        register_slots (int): number of classical register slots.
+    """
+    def __init__(self, shots, register_slots, **kwargs):
+        self.shots = shots
+        self.register_slots = register_slots
+        super().__init__(**kwargs)
+
+    def __eq__(self, other):
+        attrs = ['max_credits', 'shots', 'backend']
+        return all(getattr(self, attr) == getattr(other, attr)
+                   for attr in attrs)
+
+
+class QObjExperiment(QObjStructure):
+    """Quantum experiment represented inside a QObj.
+
+    Attributes:
+        instructions(list[QObjInstruction]): list of instructions
+    """
+    def __init__(self, instructions, **kwargs):
+        self.instructions = instructions
+
+        super().__init__(**kwargs)
+
+
+class QObjInstruction(QObjStructure):
+    """Quantum Instruction.
+
+    Attributes:
+        instructions(list[QObjInstruction]): list of instructions
+    """
+    def __init__(self, instructions, **kwargs):
+        self.instructions = instructions
+
+        super().__init__(**kwargs)

--- a/qiskit/qobj/_qobj.py
+++ b/qiskit/qobj/_qobj.py
@@ -54,15 +54,15 @@ class QObj(QObjStructure):
         id (str): QObj identifier.
         config (QObjConfig): config settings for the QObj.
         experiments (list[QObjExperiment]): list of experiments.
-        headers (QObjStructure): headers.
+        header (QObjStructure): headers.
         type (str): experiment type (QASM/PULSE).
     """
-    def __init__(self, id, config, experiments, headers, **kwargs):
+    def __init__(self, id, config, experiments, header, **kwargs):
         # pylint: disable=redefined-builtin,invalid-name
         self.id = id
         self.config = config
         self.experiments = experiments
-        self.headers = headers
+        self.header = header
         self.type = QObjType.QASM.value
 
         super().__init__(**kwargs)
@@ -100,11 +100,9 @@ class QObjInstruction(QObjStructure):
     Attributes:
         name(str): name of the gate.
         qubits(list): list of qubits to apply to the gate.
-        params(list): list of parameters for the gate.
     """
-    def __init__(self, name, qubits, params, **kwargs):
+    def __init__(self, name, qubits, **kwargs):
         self.name = name
         self.qubits = qubits
-        self.params = params
 
         super().__init__(**kwargs)

--- a/qiskit/qobj/_qobj.py
+++ b/qiskit/qobj/_qobj.py
@@ -26,6 +26,8 @@ class QObjStructure(SimpleNamespace):
     """
     General QObj structure.
     """
+    REQUIRED_ARGS = ()
+
     def as_dict(self):
         """Return a dictionary representation of the QObjStructure, recursively
         converting its public attributes.
@@ -46,6 +48,12 @@ class QObjStructure(SimpleNamespace):
         return {key: expand_item(value) for key, value
                 in self.__dict__.items() if not key.startswith('_')}
 
+    def __reduce__(self):
+        init_args = tuple(getattr(self, key) for key in self.REQUIRED_ARGS)
+        extra_args = {key: value for key, value in self.__dict__.items()
+                      if key not in self.REQUIRED_ARGS}
+        return self.__class__, init_args, extra_args
+
 
 class QObj(QObjStructure):
     """Representation of a QObj.
@@ -57,6 +65,9 @@ class QObj(QObjStructure):
         header (QObjStructure): headers.
         type (str): experiment type (QASM/PULSE).
     """
+
+    REQUIRED_ARGS = ['id', 'config', 'experiments', 'header']
+
     def __init__(self, id, config, experiments, header, **kwargs):
         # pylint: disable=redefined-builtin,invalid-name
         self.id = id
@@ -75,6 +86,8 @@ class QObjConfig(QObjStructure):
         shots (int): number of shots.
         register_slots (int): number of classical register slots.
     """
+    REQUIRED_ARGS = ['shots', 'register_slots']
+
     def __init__(self, shots, register_slots, **kwargs):
         self.shots = shots
         self.register_slots = register_slots
@@ -88,6 +101,8 @@ class QObjExperiment(QObjStructure):
     Attributes:
         instructions(list[QObjInstruction]): list of instructions
     """
+    REQUIRED_ARGS = ['instructions']
+
     def __init__(self, instructions, **kwargs):
         self.instructions = instructions
 
@@ -101,6 +116,8 @@ class QObjInstruction(QObjStructure):
         name(str): name of the gate.
         qubits(list): list of qubits to apply to the gate.
     """
+    REQUIRED_ARGS = ['name', 'qubits']
+
     def __init__(self, name, qubits, **kwargs):
         self.name = name
         self.qubits = qubits

--- a/qiskit/qobj/_utils.py
+++ b/qiskit/qobj/_utils.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2018 IBM RESEARCH. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =============================================================================
+
+"""QObj utilities and enums."""
+
+
+from enum import Enum
+
+
+class QObjType(str, Enum):
+    """
+    QObj.type allowed values.
+    """
+    QASM = 'QASM'
+    PULSE = 'PULSE'

--- a/qiskit/qobj/_utils.py
+++ b/qiskit/qobj/_utils.py
@@ -17,7 +17,6 @@
 
 """QObj utilities and enums."""
 
-
 from enum import Enum
 
 

--- a/qiskit/unroll/_jsonbackend.py
+++ b/qiskit/unroll/_jsonbackend.py
@@ -26,7 +26,7 @@ The input is a AST and a basis set and returns a json memory object::
      "qubit_labels": [["q", 0], ["v", 0]], // list[list[string, int]]
      "clbit_labels": [["c", 2]], // list[list[string, int]]
      }
-     "operations": // list[map]
+     "instructions": // list[map]
         [
             {
                 "name": , // required -- string
@@ -60,7 +60,7 @@ class JsonBackend(UnrollerBackend):
         """
         super().__init__(basis)
         self.circuit = {}
-        self.circuit['operations'] = []
+        self.circuit['instructions'] = []
         self.circuit['header'] = {
             'number_of_qubits': 0,
             'number_of_clbits': 0,
@@ -148,7 +148,7 @@ class JsonBackend(UnrollerBackend):
             if "U" not in self.basis:
                 self.basis.append("U")
             qubit_indices = [self._qubit_order_internal.get(qubit)]
-            self.circuit['operations'].append({
+            self.circuit['instructions'].append({
                 'name': "U",
                 # TODO: keep these real for now, until a later time
                 'params': [float(arg[0].real(nested_scope)),
@@ -180,7 +180,7 @@ class JsonBackend(UnrollerBackend):
                     'mask': "0x%X" % mask,
                     'val': "0x%X" % self.cval
                 }
-            self.circuit['operations'][-1]['conditional'] = conditional
+            self.circuit['instructions'][-1]['conditional'] = conditional
 
     def cx(self, qubit0, qubit1):
         """Fundamental two-qubit gate.
@@ -193,7 +193,7 @@ class JsonBackend(UnrollerBackend):
                 self.basis.append("CX")
             qubit_indices = [self._qubit_order_internal.get(qubit0),
                              self._qubit_order_internal.get(qubit1)]
-            self.circuit['operations'].append({
+            self.circuit['instructions'].append({
                 'name': 'CX',
                 'qubits': qubit_indices,
                 })
@@ -209,7 +209,7 @@ class JsonBackend(UnrollerBackend):
             self.basis.append("measure")
         qubit_indices = [self._qubit_order_internal.get(qubit)]
         clbit_indices = [self._cbit_order_internal.get(bit)]
-        self.circuit['operations'].append({
+        self.circuit['instructions'].append({
             'name': 'measure',
             'qubits': qubit_indices,
             'clbits': clbit_indices
@@ -228,7 +228,7 @@ class JsonBackend(UnrollerBackend):
             for qubitlist in qubitlists:
                 for qubits in qubitlist:
                     qubit_indices.append(self._qubit_order_internal.get(qubits))
-            self.circuit['operations'].append({
+            self.circuit['instructions'].append({
                 'name': 'barrier',
                 'qubits': qubit_indices,
                 })
@@ -243,7 +243,7 @@ class JsonBackend(UnrollerBackend):
         if "reset" not in self.basis:
             self.basis.append("reset")
         qubit_indices = [self._qubit_order_internal.get(qubit)]
-        self.circuit['operations'].append({
+        self.circuit['instructions'].append({
             'name': 'reset',
             'qubits': qubit_indices,
             })
@@ -280,7 +280,7 @@ class JsonBackend(UnrollerBackend):
             self.listen = False
             qubit_indices = [self._qubit_order_internal.get(qubit)
                              for qubit in qubits]
-            self.circuit['operations'].append({
+            self.circuit['instructions'].append({
                 'name': name,
                 # TODO: keep these real for now, until a later time
                 'params': list(map(lambda x: float(x.real(nested_scope)),
@@ -316,4 +316,4 @@ class JsonBackend(UnrollerBackend):
     def _is_circuit_valid(self):
         """Checks whether the circuit object is a valid one or not."""
         return (len(self.circuit['header']) > 0 and
-                len(self.circuit['operations']) > 0)
+                len(self.circuit['instructions']) > 0)

--- a/test/python/test_qobj.py
+++ b/test/python/test_qobj.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2018 IBM RESEARCH. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =============================================================================
+
+"""Non-string identifiers for circuit and record identifiers test"""
+
+from qiskit.qobj._qobj import QObj, QObjConfig, QObjExperiment, QObjInstruction
+from .common import QiskitTestCase
+
+
+class TestQObj(QiskitTestCase):
+    """Tests for QObj."""
+    def test_create_qobj(self):
+        """Test creation of a QObj based on the individual elements."""
+        instruction_1 = QObjInstruction(name='u1', qubits=[1], params=[0.4])
+        instruction_2 = QObjInstruction(name='u2', qubits=[1], params=[0.4, 0.2])
+        instructions = [instruction_1, instruction_2]
+        experiment_1 = QObjExperiment(instructions)
+        experiments = [experiment_1]
+        config = QObjConfig(shots=1024, register_slots=3)
+        headers = {}
+
+        qobj = QObj(id='12345', config=config,
+                    experiments=experiments, headers=headers)
+
+        expected = {'id': '12345',
+                    'headers': {},
+                    'type': 'QASM',
+                    'config': {'shots': 1024, 'register_slots': 3},
+                    'experiments': [
+                        {'instructions': [
+                            {'name': 'u1', 'params': [0.4], 'qubits': [1]},
+                            {'name': 'u2', 'params': [0.4, 0.2], 'qubits': [1]}
+                        ]}
+                    ]}
+        self.assertEqual(qobj.as_dict(), expected)

--- a/test/python/test_qobj.py
+++ b/test/python/test_qobj.py
@@ -31,10 +31,10 @@ class TestQObj(QiskitTestCase):
         experiment_1 = QObjExperiment(instructions)
         experiments = [experiment_1]
         config = QObjConfig(shots=1024, register_slots=3)
-        headers = {}
+        header = {}
 
         qobj = QObj(id='12345', config=config,
-                    experiments=experiments, headers=headers)
+                    experiments=experiments, header=header)
 
         expected = {'id': '12345',
                     'headers': {},

--- a/test/python/test_quantumprogram.py
+++ b/test/python/test_quantumprogram.py
@@ -734,7 +734,8 @@ class TestQuantumProgram(QiskitTestCase):
         out = q_program.compile(['circuitName'], backend=backend,
                                 coupling_map=coupling_map, qobj_id='cooljob')
         self.log.info(out)
-        self.assertEqual(len(out), 3)
+        self.assertEqual(out.experiments[0].name, 'circuitName')
+        self.assertEqual(out.id, 'cooljob')
 
     def test_get_compiled_configuration(self):
         """Test compiled_configuration.
@@ -885,23 +886,23 @@ class TestQuantumProgram(QiskitTestCase):
         config = {'seed': 10, 'shots': 1, 'xvals': [1, 2, 3, 4]}
         qobj1 = q_program.compile(circuits, backend=backend, shots=shots,
                                   seed=88, config=config)
-        qobj1['circuits'][0]['config']['shots'] = 50
-        qobj1['circuits'][0]['config']['xvals'] = [1, 1, 1]
+        qobj1.experiments[0].config.shots = 50
+        qobj1.experiments[0].config.xvals = [1, 1, 1]
         config['shots'] = 1000
         config['xvals'][0] = 'only for qobj2'
         qobj2 = q_program.compile(circuits, backend=backend, shots=shots,
                                   seed=88, config=config)
-        self.assertTrue(qobj1['circuits'][0]['config']['shots'] == 50)
-        self.assertTrue(qobj1['circuits'][1]['config']['shots'] == 1)
-        self.assertTrue(qobj1['circuits'][0]['config']['xvals'] == [1, 1, 1])
-        self.assertTrue(qobj1['circuits'][1]['config']['xvals'] == [1, 2, 3, 4])
-        self.assertTrue(qobj1['config']['shots'] == 1024)
-        self.assertTrue(qobj2['circuits'][0]['config']['shots'] == 1000)
-        self.assertTrue(qobj2['circuits'][1]['config']['shots'] == 1000)
-        self.assertTrue(qobj2['circuits'][0]['config']['xvals'] == [
-            'only for qobj2', 2, 3, 4])
-        self.assertTrue(qobj2['circuits'][1]['config']['xvals'] == [
-            'only for qobj2', 2, 3, 4])
+        self.assertEqual(qobj1.experiments[0].config.shots, 50)
+        self.assertEqual(qobj1.experiments[1].config.shots, 1)
+        self.assertEqual(qobj1.experiments[0].config.xvals, [1, 1, 1])
+        self.assertEqual(qobj1.experiments[1].config.xvals, [1, 2, 3, 4])
+        self.assertTrue(qobj1.config.shots, 1024)
+        self.assertTrue(qobj2.experiments[0].config.shots, 1000)
+        self.assertTrue(qobj2.experiments[1].config.shots, 1000)
+        self.assertTrue(qobj2.experiments[0].config.xvals,
+                        ['only for qobj2', 2, 3, 4])
+        self.assertTrue(qobj2.experiments[1].config.xvals,
+                        ['only for qobj2', 2, 3, 4])
 
     ###############################################################
     # Test for running programs


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This is a replacement for two previous PRs (#144 and #326) that attempted to implement features related to qobj. In light of recent changes to the qiskit core, and recent changes to the qobj spec itslef, we are going to attempt to integrate qobj as an object in the qiskit flow, pass a serialized form of it to backends, and validate them against updated schemas.

@diego-plan9 and @ewinston can you please help port over the files from your previous PRs that we should have here? @atilag can you please ensure the jobprocessor and tests are up to date? I will work on the schemas and parsing of the results received from backends.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.