### PR TITLE
Issue #471 : Permit API token to be passed by env var

### DIFF
--- a/Qconfig.py.default
+++ b/Qconfig.py.default
@@ -2,6 +2,13 @@
 # Log in to the IBM Q experience. Under "Account", generate a personal 
 # access token. Replace 'PUT_YOUR_API_TOKEN_HERE' below with the quoted
 # token string. Uncomment the APItoken variable, and you will be ready to go.
+#
+# Either:
+# 1) Replace "PUT_YOUR_API_TOKEN_HERE" below with the quoted token string.
+# Uncomment the APItoken variable, and you will be ready to go, or
+# 2) Export your API token as an environment variable called "IBMQ_API_TOKEN".
+
+import os
 
 #APItoken = 'PUT_YOUR_API_TOKEN_HERE'
 
@@ -20,4 +27,7 @@ config = {
 }
 
 if 'APItoken' not in locals():
-    raise Exception('Please set up your access token. See Qconfig.py.')
+    if 'IBMQ_API_TOKEN' in os.environ:
+        APItoken = os.environ['IBMQ_API_TOKEN']
+   else:
+        raise Exception('Please set up your access token. See Qconfig.py.')


### PR DESCRIPTION
Allow the APItoken to be taken from an environment variable if not
hard coded in the QConfig.py file.