### PR TITLE
Get named nodes removed unnecessary sorting

### DIFF
--- a/qiskit/dagcircuit/_dagcircuit.py
+++ b/qiskit/dagcircuit/_dagcircuit.py
@@ -1073,18 +1073,13 @@ class DAGCircuit:
                 self.multi_graph.remove_edge(p[0], self.output_map[w])
 
     def get_named_nodes(self, name):
-        """Return a list of "op" nodes with the given name."""
-        nlist = []
+        """Return an iterator of "op" node ids with the given name."""
         if name not in self.basis:
             raise DAGCircuitError("%s is not in the list of basis operations"
                                   % name)
 
-        # Iterate through the nodes of self in topological order
-        for n in nx.topological_sort(self.multi_graph):
-            nd = self.multi_graph.node[n]
-            if nd["type"] == "op" and nd["name"] == name:
-                nlist.append(n)
-        return nlist
+        return (node_id for node_id, data in self.multi_graph.nodes(data=True)
+                if data["type"] == "op" and data["name"] == name)
 
     def _remove_op_node(self, n):
         """Remove an operation node n.

--- a/qiskit/dagcircuit/_dagcircuit.py
+++ b/qiskit/dagcircuit/_dagcircuit.py
@@ -1072,7 +1072,7 @@ class DAGCircuit:
                 self.multi_graph.remove_edge(p[0], self.output_map[w])
 
     def get_named_nodes(self, name):
-        """Returns a list of "op" node ids with the given name."""
+        """Returns a list of "op" node ids with the given name in arbitrary order."""
         if name not in self.basis:
             raise DAGCircuitError("%s is not in the list of basis operations"
                                   % name)

--- a/qiskit/dagcircuit/_dagcircuit.py
+++ b/qiskit/dagcircuit/_dagcircuit.py
@@ -142,8 +142,7 @@ class DAGCircuit:
 
     def remove_all_ops_named(self, opname):
         """Remove all operation nodes with the given name."""
-        nlist = self.get_named_nodes(opname)
-        for n in nlist:
+        for n in self.get_named_nodes(opname):
             self._remove_op_node(n)
 
     def fs(self, number):
@@ -1073,13 +1072,15 @@ class DAGCircuit:
                 self.multi_graph.remove_edge(p[0], self.output_map[w])
 
     def get_named_nodes(self, name):
-        """Return an iterator of "op" node ids with the given name."""
+        """Returns a list of "op" node ids with the given name."""
         if name not in self.basis:
             raise DAGCircuitError("%s is not in the list of basis operations"
                                   % name)
 
-        return (node_id for node_id, data in self.multi_graph.nodes(data=True)
-                if data["type"] == "op" and data["name"] == name)
+        # We need to instantiate the full list now because the underlying multi_graph
+        # may change when users iterate over the named nodes.
+        return [node_id for node_id, data in self.multi_graph.nodes(data=True)
+                if data["type"] == "op" and data["name"] == name]
 
     def _remove_op_node(self, n):
         """Remove an operation node n.

--- a/qiskit/dagcircuit/_dagcircuit.py
+++ b/qiskit/dagcircuit/_dagcircuit.py
@@ -1072,15 +1072,15 @@ class DAGCircuit:
                 self.multi_graph.remove_edge(p[0], self.output_map[w])
 
     def get_named_nodes(self, name):
-        """Returns a list of "op" node ids with the given name in arbitrary order."""
+        """Get the set of "op" node ids with the given name."""
         if name not in self.basis:
             raise DAGCircuitError("%s is not in the list of basis operations"
                                   % name)
 
         # We need to instantiate the full list now because the underlying multi_graph
         # may change when users iterate over the named nodes.
-        return [node_id for node_id, data in self.multi_graph.nodes(data=True)
-                if data["type"] == "op" and data["name"] == name]
+        return {node_id for node_id, data in self.multi_graph.nodes(data=True)
+                if data["type"] == "op" and data["name"] == name}
 
     def _remove_op_node(self, n):
         """Remove an operation node n.

--- a/qiskit/mapper/_mapping.py
+++ b/qiskit/mapper/_mapping.py
@@ -352,9 +352,8 @@ def direction_mapper(circuit_graph, coupling_graph):
     flipped_cx_circuit.apply_operation_back("h", [("q", 0)])
     flipped_cx_circuit.apply_operation_back("h", [("q", 1)])
 
-    cx_node_list = circuit_graph.get_named_nodes("cx")
     cg_edges = coupling_graph.get_edges()
-    for cx_node in cx_node_list:
+    for cx_node in circuit_graph.get_named_nodes("cx"):
         nd = circuit_graph.multi_graph.node[cx_node]
         cxedge = tuple(nd["qargs"])
         if cxedge in cg_edges:

--- a/test/python/test_dagcircuit.py
+++ b/test/python/test_dagcircuit.py
@@ -53,16 +53,15 @@ class TestDagCircuit(QiskitTestCase):
         dag.apply_operation_back('cx', [('q', 0), ('q', 2)])
         dag.apply_operation_back('h', [('q', 2)])
 
+        # The ordering is not assured, so we only compare the output (unordered) sets.
+        # We use tuples because lists aren't hashable.
         named_nodes = dag.get_named_nodes('cx')
-        self.assertEqual(3, len(named_nodes))
-        # Since the ordering is not assured, we sort to make it certain.
-        # We have asserted here that lower node id implies that it was applied earlier.
-        named_nodes = list(sorted(named_nodes))
-        node_qargs = [dag.multi_graph.node[node_id]["qargs"] for node_id in named_nodes]
-        self.assertEqual([
-            [('q', 0), ('q', 1)],
-            [('q', 2), ('q', 1)],
-            [('q', 0), ('q', 2)]], node_qargs)
+        node_qargs = {tuple(dag.multi_graph.node[node_id]["qargs"]) for node_id in named_nodes}
+        expected_gates = {
+            (('q', 0), ('q', 1)),
+            (('q', 2), ('q', 1)),
+            (('q', 0), ('q', 2))}
+        self.assertEqual(expected_gates, node_qargs)
 
 
 if __name__ == '__main__':

--- a/test/python/test_dagcircuit.py
+++ b/test/python/test_dagcircuit.py
@@ -53,7 +53,7 @@ class TestDagCircuit(QiskitTestCase):
         dag.apply_operation_back('cx', [('q', 0), ('q', 2)])
         dag.apply_operation_back('h', [('q', 2)])
 
-        named_nodes = list(dag.get_named_nodes('cx'))
+        named_nodes = dag.get_named_nodes('cx')
         self.assertEqual(3, len(named_nodes))
         # Since the ordering is not assured, we sort to make it certain.
         # We have asserted here that lower node id implies that it was applied earlier.

--- a/test/python/test_dagcircuit.py
+++ b/test/python/test_dagcircuit.py
@@ -12,7 +12,6 @@
 import unittest
 
 from qiskit.dagcircuit import DAGCircuit
-
 from .common import QiskitTestCase
 
 
@@ -42,6 +41,28 @@ class TestDagCircuit(QiskitTestCase):
         dag.apply_operation_back('x', [qubit1], [], [], ('cr', 1))
         dag.apply_operation_back('measure', [qubit0], [clbit0], [], condition)
         dag.apply_operation_back('measure', [qubit1], [clbit1], [], condition)
+
+    def test_get_named_nodes(self):
+        dag = DAGCircuit()
+        dag.add_basis_element('h', 1, number_classical=0, number_parameters=0)
+        dag.add_basis_element('cx', 2)
+        dag.add_qreg('q', 3)
+        dag.apply_operation_back('cx', [('q', 0), ('q', 1)])
+        dag.apply_operation_back('h', [('q', 0)])
+        dag.apply_operation_back('cx', [('q', 2), ('q', 1)])
+        dag.apply_operation_back('cx', [('q', 0), ('q', 2)])
+        dag.apply_operation_back('h', [('q', 2)])
+
+        named_nodes = list(dag.get_named_nodes('cx'))
+        self.assertEqual(3, len(named_nodes))
+        # Since the ordering is not assured, we sort to make it certain.
+        # We have asserted here that lower node id implies that it was applied earlier.
+        named_nodes = list(sorted(named_nodes))
+        node_qargs = [dag.multi_graph.node[node_id]["qargs"] for node_id in named_nodes]
+        self.assertEqual([
+            [('q', 0), ('q', 1)],
+            [('q', 2), ('q', 1)],
+            [('q', 0), ('q', 2)]], node_qargs)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The get_named_nodes of DAGCircuit was unnecessarily sorting the graph nodes in topological order.

## Description
I have removed the sorting and replaced it with a list generator.

## Motivation and Context
I noticed that a decent amount of time was spent in the get_named_nodes function and noticed that it was sorting the multi_graph for no apparent reason. That's why I rewrote it.

## How Has This Been Tested?
I added a simple test case and tested all offline tests locally.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.