### PR TITLE
Preserve i->i initial layout when coupling_map satisfied

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -45,6 +45,7 @@ Fixed
 - Fix hardcoded backend mapping tests (#521)
 - Removed ``_modifiers call`` from ``reapply`` (#534)
 - Fix circuit drawer issue with filename location on windows (#543)
+- Change initial qubit layout only if the backend coupling map is not satisfied (#527)
 
 
 `0.5.3`_ - 2018-05-29

--- a/qiskit/_compiler.py
+++ b/qiskit/_compiler.py
@@ -56,6 +56,7 @@ def compile(circuits, backend,
         hpc (dict): HPC simulator parameters
         skip_transpiler (bool): If True, bypass most of the compilation process and
             creates a qobj with minimal check nor translation
+        skip_translation (bool): DEPRECATED. Use skip_transpiler instead.
 
     Returns:
         obj: the qobj to be run on the backends
@@ -64,7 +65,6 @@ def compile(circuits, backend,
         QISKitError: if any of the circuit names cannot be found on the
             Quantum Program.
     """
-    # pylint: disable=missing-param-doc, missing-type-doc
     if skip_translation:
         warnings.warn(
             "skip_translation will be called skip_transpiler in future versions.",

--- a/qiskit/_gate.py
+++ b/qiskit/_gate.py
@@ -24,10 +24,19 @@ class Gate(Instruction):
         arg = list of pairs (Register, index)
         circuit = QuantumCircuit or CompositeGate containing this gate
         """
+        self._is_multi_qubit = False
+        self._qubit_coupling = []
+        number_of_arguments = 0
         for argument in args:
+            number_of_arguments += 1
+            if number_of_arguments > 1:
+                self._qubit_coupling.append(argument)
+                self._is_multi_qubit = True
+
             if not isinstance(argument[0], QuantumRegister):
                 raise QISKitError("argument not (QuantumRegister, int) "
                                   + "tuple")
+
         super().__init__(name, param, args, circuit)
 
     def inverse(self):
@@ -38,3 +47,13 @@ class Gate(Instruction):
         """Add controls to this gate."""
         # pylint: disable=unused-argument
         raise QISKitError("control not implemented")
+
+    def is_multi_qubit(self):
+        """Returns True if this Gate is uses multiple qubits as arguments"""
+        return self._is_multi_qubit
+
+    def get_qubit_coupling(self):
+        """Gets the coupling graph of the qubits in case this is a multi-qubit gate"""
+        if not self.is_multi_qubit():
+            raise QISKitError("Can't get the qubit coupling of non multi-qubit gates!")
+        return self._qubit_coupling

--- a/qiskit/_instruction.py
+++ b/qiskit/_instruction.py
@@ -47,7 +47,7 @@ class Instruction(object):
             raise QISKitError("Instruction's circuit not assigned")
 
     def c_if(self, classical, val):
-        """Add classical control on register clasical and value val."""
+        """Add classical control on register classical and value val."""
         self.check_circuit()
         self.circuit._check_creg(classical)
         if val < 0:

--- a/qiskit/_quantumprogram.py
+++ b/qiskit/_quantumprogram.py
@@ -932,7 +932,7 @@ class QuantumProgram(object):
     def compile(self, name_of_circuits=None, backend="local_qasm_simulator",
                 config=None, basis_gates=None, coupling_map=None,
                 initial_layout=None, shots=1024, max_credits=10, seed=None,
-                qobj_id=None, hpc=None, skip_translation=False):
+                qobj_id=None, hpc=None, skip_transpiler=False):
         """Compile the circuits into the execution list.
 
         .. deprecated:: 0.5
@@ -961,7 +961,7 @@ class QuantumProgram(object):
         qobj = qiskit.wrapper.compile(list_of_circuits, my_backend,
                                       config, basis_gates, coupling_map, initial_layout,
                                       shots, max_credits, seed, qobj_id, hpc,
-                                      skip_translation)
+                                      skip_transpiler)
         return qobj
 
     def reconfig(self, qobj, backend=None, config=None, shots=None, max_credits=None, seed=None):
@@ -1126,7 +1126,7 @@ class QuantumProgram(object):
     def execute(self, name_of_circuits=None, backend="local_qasm_simulator",
                 config=None, timeout=60, basis_gates=None,
                 coupling_map=None, initial_layout=None, shots=1024,
-                max_credits=3, seed=None, hpc=None, skip_translation=False):
+                max_credits=3, seed=None, hpc=None, skip_transpiler=False):
         """Execute, compile, and run an array of quantum circuits).
 
         This builds the internal "to execute" list which is list of quantum
@@ -1174,7 +1174,7 @@ class QuantumProgram(object):
                                 'omp_num_threads': Numeric
                             }
 
-            skip_translation (bool): If True, bypass most of the compilation process and
+            skip_transpiler (bool): If True, bypass most of the compilation process and
                 creates a qobj with minimal check nor translation
         Returns:
             Result: status done and populates the internal __quantum_program with the data.
@@ -1191,7 +1191,7 @@ class QuantumProgram(object):
                             basis_gates=basis_gates,
                             coupling_map=coupling_map, initial_layout=initial_layout,
                             shots=shots, max_credits=max_credits, seed=seed,
-                            hpc=hpc, skip_translation=skip_translation)
+                            hpc=hpc, skip_transpiler=skip_transpiler)
         result = self.run(qobj, timeout=timeout)
         return result
 

--- a/qiskit/_quantumprogram.py
+++ b/qiskit/_quantumprogram.py
@@ -932,14 +932,19 @@ class QuantumProgram(object):
     def compile(self, name_of_circuits=None, backend="local_qasm_simulator",
                 config=None, basis_gates=None, coupling_map=None,
                 initial_layout=None, shots=1024, max_credits=10, seed=None,
-                qobj_id=None, hpc=None, skip_transpiler=False):
+                qobj_id=None, hpc=None, skip_transpiler=False, skip_translation=False):
         """Compile the circuits into the execution list.
 
         .. deprecated:: 0.5
             The `coupling_map` parameter as a dictionary will be deprecated in
             upcoming versions. Using the coupling_map as a list is recommended.
         """
-
+        # pylint: disable=missing-param-doc, missing-type-doc
+        if skip_translation:
+            warnings.warn(
+                "skip_translation will be called skip_transpiler in future versions.",
+                DeprecationWarning)
+            skip_transpiler = True
         if isinstance(coupling_map, dict):
             coupling_map = coupling_dict2list(coupling_map)
             warnings.warn(
@@ -1126,7 +1131,7 @@ class QuantumProgram(object):
     def execute(self, name_of_circuits=None, backend="local_qasm_simulator",
                 config=None, timeout=60, basis_gates=None,
                 coupling_map=None, initial_layout=None, shots=1024,
-                max_credits=3, seed=None, hpc=None, skip_transpiler=False):
+                max_credits=3, seed=None, hpc=None, skip_transpiler=False, skip_translation=False):
         """Execute, compile, and run an array of quantum circuits).
 
         This builds the internal "to execute" list which is list of quantum
@@ -1183,6 +1188,12 @@ class QuantumProgram(object):
             The `coupling_map` parameter as a dictionary will be deprecated in
             upcoming versions. Using the coupling_map as a list is recommended.
         """
+        # pylint: disable=missing-param-doc, missing-type-doc
+        if skip_translation:
+            warnings.warn(
+                "skip_translation will be called skip_transpiler in future versions.",
+                DeprecationWarning)
+            skip_transpiler = True
         # TODO: Jay: currently basis_gates, coupling_map, initial_layout, shots,
         # max_credits, and seed are extra inputs but I would like them to go
         # into the config

--- a/qiskit/wrapper/_wrapper.py
+++ b/qiskit/wrapper/_wrapper.py
@@ -153,17 +153,17 @@ def compile(circuits, backend,
         hpc (dict): HPC simulator parameters
         skip_transpiler (bool): If True, bypass most of the compilation process and
             creates a qobj with minimal check nor translation
+        skip_translation (bool): DEPRECATED. Use skip_transpiler instead.
     Returns:
         obj: the qobj to be run on the backends
     """
-    # pylint: disable=missing-param-doc, missing-type-doc
+    # pylint: disable=redefined-builtin
     if skip_translation:
         warnings.warn(
             "skip_translation will be called skip_transpiler in future versions.",
             DeprecationWarning)
         skip_transpiler = True
 
-    # pylint: disable=redefined-builtin
     if isinstance(backend, str):
         backend = _DEFAULT_PROVIDER.get_backend(backend)
     return qiskit._compiler.compile(circuits, backend,

--- a/qiskit/wrapper/_wrapper.py
+++ b/qiskit/wrapper/_wrapper.py
@@ -135,7 +135,7 @@ def get_backend(name):
 def compile(circuits, backend,
             config=None, basis_gates=None, coupling_map=None, initial_layout=None,
             shots=1024, max_credits=10, seed=None, qobj_id=None, hpc=None,
-            skip_translation=False):
+            skip_transpiler=False):
     """Compile a list of circuits into a qobj.
 
     Args:
@@ -150,7 +150,7 @@ def compile(circuits, backend,
         seed (int): random seed for simulators
         qobj_id (int): identifier for the generated qobj
         hpc (dict): HPC simulator parameters
-        skip_translation (bool): If True, bypass most of the compilation process and
+        skip_transpiler (bool): If True, bypass most of the compilation process and
             creates a qobj with minimal check nor translation
     Returns:
         obj: the qobj to be run on the backends
@@ -161,13 +161,13 @@ def compile(circuits, backend,
     return qiskit._compiler.compile(circuits, backend,
                                     config, basis_gates, coupling_map, initial_layout,
                                     shots, max_credits, seed, qobj_id, hpc,
-                                    skip_translation)
+                                    skip_transpiler)
 
 
 def execute(circuits, backend,
             config=None, basis_gates=None, coupling_map=None, initial_layout=None,
             shots=1024, max_credits=10, seed=None, qobj_id=None, hpc=None,
-            skip_translation=False):
+            skip_transpiler=False):
     """Executes a set of circuits.
 
     Args:
@@ -182,7 +182,7 @@ def execute(circuits, backend,
         seed (int): random seed for simulators
         qobj_id (int): identifier for the generated qobj
         hpc (dict): HPC simulator parameters
-        skip_translation (bool): skip most of the compile steps and produce qobj directly
+        skip_transpiler (bool): skip most of the compile steps and produce qobj directly
 
     Returns:
         BaseJob: returns job instance derived from BaseJob
@@ -192,7 +192,7 @@ def execute(circuits, backend,
     qobj = compile(circuits, backend,
                    config, basis_gates, coupling_map, initial_layout,
                    shots, max_credits, seed, qobj_id, hpc,
-                   skip_translation)
+                   skip_transpiler)
     # XXX When qobj is done this should replace q_job
     q_job = QuantumJob(qobj, backend=backend, preformatted=True, resources={
         'max_credits': qobj['config']['max_credits']})

--- a/qiskit/wrapper/_wrapper.py
+++ b/qiskit/wrapper/_wrapper.py
@@ -8,6 +8,7 @@
 """Helper module for simplified QISKit usage."""
 
 import os
+import warnings
 import qiskit._compiler
 from qiskit import QISKitError
 from qiskit.backends.ibmq.ibmqprovider import IBMQProvider
@@ -135,7 +136,7 @@ def get_backend(name):
 def compile(circuits, backend,
             config=None, basis_gates=None, coupling_map=None, initial_layout=None,
             shots=1024, max_credits=10, seed=None, qobj_id=None, hpc=None,
-            skip_transpiler=False):
+            skip_transpiler=False, skip_translation=False):
     """Compile a list of circuits into a qobj.
 
     Args:
@@ -155,6 +156,13 @@ def compile(circuits, backend,
     Returns:
         obj: the qobj to be run on the backends
     """
+    # pylint: disable=missing-param-doc, missing-type-doc
+    if skip_translation:
+        warnings.warn(
+            "skip_translation will be called skip_transpiler in future versions.",
+            DeprecationWarning)
+        skip_transpiler = True
+
     # pylint: disable=redefined-builtin
     if isinstance(backend, str):
         backend = _DEFAULT_PROVIDER.get_backend(backend)
@@ -167,7 +175,7 @@ def compile(circuits, backend,
 def execute(circuits, backend,
             config=None, basis_gates=None, coupling_map=None, initial_layout=None,
             shots=1024, max_credits=10, seed=None, qobj_id=None, hpc=None,
-            skip_transpiler=False):
+            skip_transpiler=False, skip_translation=False):
     """Executes a set of circuits.
 
     Args:
@@ -187,6 +195,13 @@ def execute(circuits, backend,
     Returns:
         BaseJob: returns job instance derived from BaseJob
     """
+    # pylint: disable=missing-param-doc, missing-type-doc
+    if skip_translation:
+        warnings.warn(
+            "skip_translation will be called skip_transpiler in future versions.",
+            DeprecationWarning)
+        skip_transpiler = True
+
     if isinstance(backend, str):
         backend = _DEFAULT_PROVIDER.get_backend(backend)
     qobj = compile(circuits, backend,

--- a/test/python/test_skip_transpiler.py
+++ b/test/python/test_skip_transpiler.py
@@ -19,7 +19,7 @@ class CompileSkipTranslationTest(QiskitTestCase):
 
     def test_simple_compile(self):
         """
-        Compares with and without skip_translation
+        Compares with and without skip_transpiler
         """
         name = 'test_simple'
         qp = QuantumProgram()
@@ -31,9 +31,9 @@ class CompileSkipTranslationTest(QiskitTestCase):
         qc.measure(qr, cr)
 
         rtrue = qp.compile([name], backend='local_qasm_simulator', shots=1024,
-                           skip_translation=True)
+                           skip_transpiler=True)
         rfalse = qp.compile([name], backend='local_qasm_simulator', shots=1024,
-                            skip_translation=False)
+                            skip_transpiler=False)
         self.assertEqual(rtrue['config'], rfalse['config'])
         self.assertEqual(rtrue['circuits'], rfalse['circuits'])
 
@@ -48,8 +48,8 @@ class CompileSkipTranslationTest(QiskitTestCase):
         qc.u2(3.14, 1.57, qr[0])
         qc.measure(qr, cr)
 
-        rtrue = qp.execute(name, seed=seed, skip_translation=True)
-        rfalse = qp.execute(name, seed=seed, skip_translation=False)
+        rtrue = qp.execute(name, seed=seed, skip_transpiler=True)
+        rfalse = qp.execute(name, seed=seed, skip_transpiler=False)
         self.assertEqual(rtrue.get_counts(), rfalse.get_counts())
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
When a circuit already satisfies the coupling_map on the backend, the swap_mapper should not insert any swaps. This means passing an `initial_layout` of `q[i]->q[i]`.

PR #478 optimizes the initial layout, but that creates unexpected behavior when the coupling map is already satisfied. Here, I only apply the optimization of #478 if swaps are indeed needed.

The other thing that this PR does is a slight name change: `skip_translation` -> `skip_transpiler`, to get ready for the transpiler PR.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Issue was raised here:
https://quantumexperience.ng.bluemix.net/qx/community/question?questionId=5b0d17f943fb6e0038a623bf

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.