### PR TITLE
Rename repository to 'qiskit-core'

### DIFF
--- a/.github/CONTRIBUTING.rst
+++ b/.github/CONTRIBUTING.rst
@@ -12,7 +12,7 @@ Issue reporting
 ~~~~~~~~~~~~~~~
 
 This is a good point to start, when you find a problem please add
-it to the `issue tracker <https://github.com/QISKit/qiskit-sdk-py/issues>`_.
+it to the `issue tracker <https://github.com/QISKit/qiskit-core/issues>`_.
 The ideal report should include the steps to reproduce it.
 
 Doubts solving
@@ -63,10 +63,10 @@ Linux and Mac
 
 .. code::
 
-    qiskit-sdk-py$ mkdir out
-    qiskit-sdk-py$ cd out
-    qiskit-sdk-py/out$ cmake ..
-    qiskit-sdk-py/out$ make
+    qiskit-core$ mkdir out
+    qiskit-core$ cd out
+    qiskit-core/out$ cmake ..
+    qiskit-core/out$ make
 
 Windows
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -153,7 +153,7 @@ jobs:
     # github pages documentation update (GNU/Linux, Python 3.5)
     - stage: deploy doc and pypi
       <<: *stage_linux_no_compile
-      if: branch = stable and repo = QISKit/qiskit-sdk-py and type = push
+      if: branch = stable and repo = QISKit/qiskit-core and type = push
       script: cd ..
       deploy:
         <<: *deploy_ghpages
@@ -161,7 +161,7 @@ jobs:
     # GNU/Linux, Python 3.5
     - stage: deploy doc and pypi
       <<: *stage_linux
-      if: branch = stable and repo = QISKit/qiskit-sdk-py and type = push
+      if: branch = stable and repo = QISKit/qiskit-core and type = push
       install: mkdir out && cd out && cmake $CMAKE_FLAGS ..
       script: cd ..
       deploy:
@@ -170,7 +170,7 @@ jobs:
     # OSX, Python 3.latest (brew does not support versions)
     - stage: deploy doc and pypi
       <<: *stage_osx
-      if: branch = stable and repo = QISKit/qiskit-sdk-py and type = push
+      if: branch = stable and repo = QISKit/qiskit-core and type = push
       install: mkdir out && cd out && cmake $CMAKE_FLAGS ..
       script: cd ..
       deploy:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Quantum Information Science Kit (QISKit)
 
 [![PyPI](https://img.shields.io/pypi/v/qiskit.svg)](https://pypi.python.org/pypi/qiskit)
-[![Build Status](https://travis-ci.org/QISKit/qiskit-sdk-py.svg?branch=master)](https://travis-ci.org/QISKit/qiskit-sdk-py)
+[![Build Status](https://travis-ci.org/QISKit/qiskit-core.svg?branch=master)](https://travis-ci.org/QISKit/qiskit-core)
 
 The Quantum Information Science Kit (**QISKit** for short) is a software development kit (SDK) for
 working with [OpenQASM](https://github.com/QISKit/qiskit-openqasm) and the

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -45,4 +45,4 @@ Authors (alphabetical)
 Luciano Bello, Jim Challenger, Andrew Cross, Ismael Faro, Jay Gambetta,
 Juan Gomez, Paco Martin, Ali Javadi-Abhari, Diego Moreda, Jesus Perez,
 Erick Winston and Chris Wood,
-along with `many contributors <https://github.com/QISKit/qiskit-sdk-py/blob/master/CONTRIBUTORS.md>`_.
+along with `many contributors <https://github.com/QISKit/qiskit-core/blob/master/CONTRIBUTORS.md>`_.

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -114,10 +114,10 @@ Depending on the system and setup, appending "sudo -H" before the
 
 
 For additional troubleshooting tips, see the `QISKit troubleshooting page
-<https://github.com/QISKit/qiskit-sdk-py/wiki/QISKit-Troubleshooting>`_
+<https://github.com/QISKit/qiskit-core/wiki/QISKit-Troubleshooting>`_
 on the project's GitHub wiki.
 
 .. _tutorials: https://github.com/QISKit/qiskit-tutorial
 .. _tutorials repository: https://github.com/QISKit/qiskit-tutorial
-.. _documentation for contributors: https://github.com/QISKit/qiskit-sdk-py/blob/master/.github/CONTRIBUTING.rst
-.. _Qconfig.py.default: https://github.com/QISKit/qiskit-sdk-py/blob/stable/Qconfig.py.default
+.. _documentation for contributors: https://github.com/QISKit/qiskit-core/blob/master/.github/CONTRIBUTING.rst
+.. _Qconfig.py.default: https://github.com/QISKit/qiskit-core/blob/stable/Qconfig.py.default

--- a/doc/ja/install.rst
+++ b/doc/ja/install.rst
@@ -40,11 +40,11 @@ QISKitをインストールする最も簡単な方法はPIP tool(Pythonのパ�
 
 .. code:: sh
 
-    git clone https://github.com/QISKit/qiskit-sdk-py
-    cd qiskit-sdk-py
+    git clone https://github.com/QISKit/qiskit-core
+    cd qiskit-core
 
 - もしGitをインストールしていない場合は、
-  `QISKit SDK GitHub repo <https://github.com/QISKit/qiskit-sdk-py>`__ の
+  `QISKit SDK GitHub repo <https://github.com/QISKit/qiskit-core>`__ の
   "Clone or download"ボタンをクリックして、
   その後ダウンロードしたファイルを展開し、そのディレクトリーに移動し作業を開始します。
 

--- a/doc/ja/qiskit.rst
+++ b/doc/ja/qiskit.rst
@@ -21,7 +21,7 @@ QISKitは、深さが限定的な量子回路を設計して直近の応用を�
 ----------------
 QISKitプロジェクトの構成は以下の通りです:
 
-* `QISKit SDK <https://github.com/IBM/qiskit-sdk-py>`_:
+* `QISKit SDK <https://github.com/QISKit/qiskit-core>`_:
   量子コンピューターのプログラムやアプリケーションを開発して実験を行うためのPythonソフトウェア開発キット
 
 * `QISKit API <https://github.com/IBM/qiskit-api-py>`_:

--- a/doc/ko/README.md
+++ b/doc/ko/README.md
@@ -1,7 +1,7 @@
 # Quantum Information Science Kit (QISKit)
 
 [![PyPI](https://img.shields.io/pypi/v/qiskit.svg)](https://pypi.python.org/pypi/qiskit)
-[![Build Status](https://travis-ci.org/QISKit/qiskit-sdk-py.svg?branch=master)](https://travis-ci.org/QISKit/qiskit-sdk-py)
+[![Build Status](https://travis-ci.org/QISKit/qiskit-core.svg?branch=master)](https://travis-ci.org/QISKit/qiskit-core)
 
 **QISKit**은 [OpenQASM](https://github.com/QISKit/qiskit-openqasm)과 [IBM Q experience (QX)](https://quantumexperience.ng.bluemix.net/)에서 사용할 수 있는 SDK(software development kit)입니다.
 
@@ -37,14 +37,14 @@ QISKit SDK 레파지토리를 여러분의 로컬 머신에 Clone하는 다른 �
 
 #### Manual download
 
-수동 다운로드 방법으로 이 웹페이지의 상단의 "Clone or download" 버튼을 누르세요 (혹은 git clone 커맨드 상에 보이는 URL을 통해), 만일 필요하다면 압축을 풀고 폴더 이름을 터미널 상에서 다음과 같이 바꾸세요. **qiskit-sdk-py folder**
+수동 다운로드 방법으로 이 웹페이지의 상단의 "Clone or download" 버튼을 누르세요 (혹은 git clone 커맨드 상에 보이는 URL을 통해), 만일 필요하다면 압축을 풀고 폴더 이름을 터미널 상에서 다음과 같이 바꾸세요. **qiskit-core folder**
 
 #### Git download
 
 혹은, 만일 여러분이 이미 Git을 설치했다면, 다음의 커맨드를 실행하세요:
 ```
-    git clone https://github.com/QISKit/qiskit-sdk-py
-    cd qiskit-sdk-py
+    git clone https://github.com/QISKit/qiskit-core
+    cd qiskit-core
 ```
 
 #### Setup your enviroment
@@ -134,7 +134,7 @@ QISKit은 본래 [IBM Research](http://www.research.ibm.com/)연구팀과 [IBM-Q
 
 ## Multilanguage guide
 
-* **[Korean Translation](https://github.com/QISKit/qiskit-sdk-py/tree/master/doc/ko/README-ko.md)**, 한글 기본 가이드 라인
+* **[Korean Translation](https://github.com/QISKit/qiskit-core/tree/master/doc/ko/README-ko.md)**, 한글 기본 가이드 라인
 
 ## Authors (alphabetical)
 
@@ -142,7 +142,7 @@ QISKit was originally authored by
 Luciano Bello, Jim Challenger, Andrew Cross, Ismael Faro, Jay Gambetta, Juan Gomez,
 Ali Javadi-Abhari, Paco Martin, Diego Moreda, Jesus Perez, Erick Winston and Chris Wood.
 
-And continues to grow with the help and work of [many people](https://github.com/QISKit/qiskit-sdk-py/tree/master/CONTRIBUTORS.md) who contribute
+And continues to grow with the help and work of [many people](https://github.com/QISKit/qiskit-core/tree/master/CONTRIBUTORS.md) who contribute
 to the project at different levels.
 
 ## License

--- a/doc/qiskit.rst
+++ b/doc/qiskit.rst
@@ -21,7 +21,7 @@ Project Overview
 ----------------
 The QISKit project comprises:
 
-* `QISKit SDK <https://github.com/QISKit/qiskit-sdk-py>`_: Python software 
+* `QISKit SDK <https://github.com/QISKit/qiskit-core>`_: Python software 
   development kit for writing quantum computing experiments, programs, and 
   applications.
 

--- a/doc/zh/README.md
+++ b/doc/zh/README.md
@@ -1,7 +1,7 @@
 ﻿# Quantum Information Science Kit (QISKit)
 
 [![PyPI](https://img.shields.io/pypi/v/qiskit.svg)](https://pypi.python.org/pypi/qiskit)
-[![Build Status](https://travis-ci.org/QISKit/qiskit-sdk-py.svg?branch=master)](https://travis-ci.org/QISKit/qiskit-sdk-py)
+[![Build Status](https://travis-ci.org/QISKit/qiskit-core.svg?branch=master)](https://travis-ci.org/QISKit/qiskit-core)
 
 **QISKit**是一个用于和 [OpenQASM](https://github.com/QISKit/qiskit-openqasm)和
 [IBM Q experience (QX)](https://quantumexperience.ng.bluemix.net/)协同工作的软件开发工具包(SDK)。
@@ -12,7 +12,7 @@
 **我们使用 GitHub issues 来追踪需求和错误。详见**
 [IBM Q experience community](https://quantumexperience.ng.bluemix.net/qx/community) **中的提问和讨论。**
 **如果您有意对 QISKit 做出贡献，请参见我们的**
-[contribution guidelines](https://github.com/QISKit/qiskit-sdk-py/blob/master/.github/CONTRIBUTING.rst)。
+[contribution guidelines](https://github.com/QISKit/qiskit-core/blob/master/.github/CONTRIBUTING.rst)。
 
 链接索引:
 
@@ -53,7 +53,7 @@ PIP 为以下平台预装有二进制版本：
 #### 配置您的安装环境
 
 我们建议采用python虚拟环境来提升运行体验。更多信息请参见
-[Environment Setup documentation](https://github.com/QISKit/qiskit-sdk-py/blob/master/doc/install.rst#3.1-Setup-the-environment) 。
+[Environment Setup documentation](https://github.com/QISKit/qiskit-core/blob/master/doc/install.rst#3.1-Setup-the-environment) 。
 
 ## 创建您的第一个量子程序
 
@@ -105,7 +105,7 @@ print(sim_result.get_counts("bell"))
 COMPLETED
 {'counts': {'00': 512, '11': 512}}
 ```
-可以在 [这里](https://github.com/QISKit/qiskit-sdk-py/blob/master/examples/python/hello_quantum.py)找到此例的脚本。
+可以在 [这里](https://github.com/QISKit/qiskit-core/blob/master/examples/python/hello_quantum.py)找到此例的脚本。
 
 ### 在一个真实的量子芯片上执行您的程序
 
@@ -119,7 +119,7 @@ COMPLETED
    账号，如果您还没有的话。
 2. 在IBM Q experience网页上取得一个API 令牌： "`My Account`" >
    "`Personal Access Token`"。这个API令牌将使您可以在IBM Q 体验后端上运行您的程序。
-   [示例](https://github.com/QISKit/qiskit-sdk-py/blob/master/doc/example_real_backend.rst)。
+   [示例](https://github.com/QISKit/qiskit-core/blob/master/doc/example_real_backend.rst)。
 3. 之后我们将创建一个新的文件叫 `Qconfig.py` 并在其中插入 API 令牌。此文件必须包含以下内容：
 ```python
 APItoken = 'MY_API_TOKEN'
@@ -160,8 +160,8 @@ Q_program.set_api(Qconfig.APItoken, Qconfig.config["url"], verify=False,
 那么您可以复制和修改这些notebooks来创建您自己的实验。
 
 如要将教程安装在 QISKit SDK 中，请参见
-[安装详述](https://github.com/QISKit/qiskit-sdk-py/blob/master/doc/install.rst#Install-Jupyter-based-tutorials)。 完整的 SDK
-文档请参见 [*doc* directory](https://github.com/QISKit/qiskit-sdk-py/blob/master/doc/qiskit.rst) 和
+[安装详述](https://github.com/QISKit/qiskit-core/blob/master/doc/install.rst#Install-Jupyter-based-tutorials)。 完整的 SDK
+文档请参见 [*doc* directory](https://github.com/QISKit/qiskit-core/blob/master/doc/qiskit.rst) 和
 [QISKit 官网](https://www.qiskit.org/documentation)。
 
 ## 更多信息
@@ -183,11 +183,11 @@ QISKit 最早是由[IBM Research](http://www.research.ibm.com/)研究中心的
 [IBM-Q](http://www.research.ibm.com/ibm-q/) 团队的研究人员和开发人员开发的，
 旨在提供一个与量子计算机配套的高水平的开发工具包。
 
-欲知更多有关 QISKit 和更广泛地有关量子计算的提问和讨论请访问 [IBM Q experience community](https://quantumexperience.ng.bluemix.net/qx/community)。 如果您有兴趣为 QISKit 做出贡献，请参见我们的 [contribution guidelines](https://github.com/QISKit/qiskit-sdk-py/blob/master/.github/CONTRIBUTING.rst)。
+欲知更多有关 QISKit 和更广泛地有关量子计算的提问和讨论请访问 [IBM Q experience community](https://quantumexperience.ng.bluemix.net/qx/community)。 如果您有兴趣为 QISKit 做出贡献，请参见我们的 [contribution guidelines](https://github.com/QISKit/qiskit-core/blob/master/.github/CONTRIBUTING.rst)。
 
 ## 多语言指导
 
-* **[Korean Translation](https://github.com/QISKit/qiskit-sdk-py/blob/master/doc/ko/README.md)**， 基本的韩语指导。
+* **[Korean Translation](https://github.com/QISKit/qiskit-core/blob/master/doc/ko/README.md)**， 基本的韩语指导。
 
 ## 作者 (按字母顺序)
 
@@ -195,7 +195,7 @@ QISKit was originally authored by
 Luciano Bello, Jim Challenger, Andrew Cross, Ismael Faro, Jay Gambetta, Juan Gomez,
 Ali Javadi-Abhari, Paco Martin, Diego Moreda, Jesus Perez, Erick Winston and Chris Wood.
 
-And continues to grow with the help and work of [many people](https://github.com/QISKit/qiskit-sdk-py/tree/master/CONTRIBUTORS.md) who contribute
+And continues to grow with the help and work of [many people](https://github.com/QISKit/qiskit-core/tree/master/CONTRIBUTORS.md) who contribute
 to the project at different levels.
 
 ## 版权许可证

--- a/qiskit/backends/local/qasm_simulator_cpp.py
+++ b/qiskit/backends/local/qasm_simulator_cpp.py
@@ -54,7 +54,7 @@ class QasmSimulatorCpp(BaseBackend):
 
     DEFAULT_CONFIGURATION = {
         'name': 'local_qasm_simulator_cpp',
-        'url': 'https://github.com/QISKit/qiskit-sdk-py/src/qasm-simulator-cpp',
+        'url': 'https://github.com/QISKit/qiskit-core/src/qasm-simulator-cpp',
         'simulator': True,
         'local': True,
         'description': 'A C++ realistic noise simulator for qobj files',
@@ -110,7 +110,7 @@ class CliffordSimulatorCpp(BaseBackend):
 
     DEFAULT_CONFIGURATION = {
         'name': 'local_clifford_simulator_cpp',
-        'url': 'https://github.com/QISKit/qiskit-sdk-py/src/qasm-simulator-cpp',
+        'url': 'https://github.com/QISKit/qiskit-core/src/qasm-simulator-cpp',
         'simulator': True,
         'local': True,
         'description': 'A C++ Clifford simulator with approximate noise',

--- a/qiskit/backends/local/qasm_simulator_py.py
+++ b/qiskit/backends/local/qasm_simulator_py.py
@@ -101,7 +101,7 @@ class QasmSimulatorPy(BaseBackend):
 
     DEFAULT_CONFIGURATION = {
         'name': 'local_qasm_simulator_py',
-        'url': 'https://github.com/QISKit/qiskit-sdk-py',
+        'url': 'https://github.com/QISKit/qiskit-core',
         'simulator': True,
         'local': True,
         'description': 'A python simulator for qasm files',

--- a/qiskit/backends/local/statevector_simulator_cpp.py
+++ b/qiskit/backends/local/statevector_simulator_cpp.py
@@ -34,7 +34,7 @@ class StatevectorSimulatorCpp(QasmSimulatorCpp):
 
     DEFAULT_CONFIGURATION = {
         'name': 'local_statevector_simulator_cpp',
-        'url': 'https://github.com/QISKit/qiskit-sdk-py/src/qasm-simulator-cpp',
+        'url': 'https://github.com/QISKit/qiskit-core/src/qasm-simulator-cpp',
         'simulator': True,
         'local': True,
         'description': 'A C++ statevector simulator for qobj files',

--- a/qiskit/backends/local/statevector_simulator_py.py
+++ b/qiskit/backends/local/statevector_simulator_py.py
@@ -41,7 +41,7 @@ class StatevectorSimulatorPy(QasmSimulatorPy):
 
     DEFAULT_CONFIGURATION = {
         'name': 'local_statevector_simulator_py',
-        'url': 'https://github.com/QISKit/qiskit-sdk-py',
+        'url': 'https://github.com/QISKit/qiskit-core',
         'simulator': True,
         'local': True,
         'description': 'A Python statevector simulator for qobj files',

--- a/qiskit/backends/local/statevector_simulator_sympy.py
+++ b/qiskit/backends/local/statevector_simulator_sympy.py
@@ -127,7 +127,7 @@ class StatevectorSimulatorSympy(BaseBackend):
 
     DEFAULT_CONFIGURATION = {
         'name': 'local_statevector_simulator_sympy',
-        'url': 'https://github.com/QISKit/qiskit-sdk-py',
+        'url': 'https://github.com/QISKit/qiskit-core',
         'simulator': True,
         'local': True,
         'description': 'A sympy-based statevector simulator',

--- a/qiskit/backends/local/unitary_simulator_py.py
+++ b/qiskit/backends/local/unitary_simulator_py.py
@@ -112,7 +112,7 @@ class UnitarySimulatorPy(BaseBackend):
 
     DEFAULT_CONFIGURATION = {
         'name': 'local_unitary_simulator_py',
-        'url': 'https://github.com/QISKit/qiskit-sdk-py',
+        'url': 'https://github.com/QISKit/qiskit-core',
         'simulator': True,
         'local': True,
         'description': 'A python simulator for unitary matrix',

--- a/qiskit/backends/local/unitary_simulator_sympy.py
+++ b/qiskit/backends/local/unitary_simulator_sympy.py
@@ -54,7 +54,7 @@ class UnitarySimulatorSympy(BaseBackend):
 
     DEFAULT_CONFIGURATION = {
         'name': 'local_unitary_simulator_sympy',
-        'url': 'https://github.com/QISKit/qiskit-sdk-py',
+        'url': 'https://github.com/QISKit/qiskit-core',
         'simulator': True,
         'local': True,
         'description': 'A sympy simulator for unitary matrix',

--- a/setup.py.in
+++ b/setup.py.in
@@ -101,7 +101,7 @@ setup(
     long_description="""QISKit is a software development kit for writing
         quantum computing experiments, programs, and applications. Works with
         Python 3.5 and 3.6""",
-    url="https://github.com/QISKit/qiskit-sdk-py",
+    url="https://github.com/QISKit/qiskit-core",
     author="QISKit Development Team",
     author_email="qiskit@us.ibm.com",
     license="Apache 2.0",

--- a/src/qasm-simulator-cpp/README.md
+++ b/src/qasm-simulator-cpp/README.md
@@ -11,7 +11,7 @@ Copyright (c) 2017 IBM Corporation. All Rights Reserved.
 
 ### Description
 
-*QASM Simulator* is a quantum circuit simulator written in C++ that includes a variety of realistic circuit level noise models. The simulator may be run as a command line application to evaluate quantum programs specified by a *Quantum program OBJect (__QObj__)*. It may also be used as a local backend in the *Quantum Information Science Kit ([__QISKit__](https://www.qiskit.org))* [Python SDK](https://github.com/QISKit/qiskit-sdk-py).
+*QASM Simulator* is a quantum circuit simulator written in C++ that includes a variety of realistic circuit level noise models. The simulator may be run as a command line application to evaluate quantum programs specified by a *Quantum program OBJect (__QObj__)*. It may also be used as a local backend in the *Quantum Information Science Kit ([__QISKit__](https://www.qiskit.org))* [Python SDK](https://github.com/QISKit/qiskit-core).
 
 ## Contents
 
@@ -19,7 +19,7 @@ Copyright (c) 2017 IBM Corporation. All Rights Reserved.
 * [Using the simulator](#using-the-simulator)
   * [Running from the command line](#running-from-the-command-line)
   * [Running in Python](#running-in-python)
-  * [Running as a backend for qiskit-sdk-py](#running-as-a-backend-for-qiskit-sdk-py)
+  * [Running as a backend for qiskit-core](#running-as-a-backend-for-qiskit-core)
   * [Simulator output](#simulator-output)
 * [Config Settings](#config-settings)
   * [Using parallelization](#using-parallelization)
@@ -62,7 +62,7 @@ This script installs the following platform specific dependencies:
 
 ### Building with Make
 
-The simulator can be build with *Make*. By default this will build the simulator executable `qasm_simulator_cpp` at  `qiskit-sdk-py/out/qasm-simulator-cpp/qasm_simulator_cpp`. This may be done from the base `qiskit-sdk-py` folder, or the source folder `qiskit-sdk-py/src/qasm-simulator-cpp` by running:
+The simulator can be build with *Make*. By default this will build the simulator executable `qasm_simulator_cpp` at  `qiskit-core/out/qasm-simulator-cpp/qasm_simulator_cpp`. This may be done from the base `qiskit-core` folder, or the source folder `qiskit-core/src/qasm-simulator-cpp` by running:
 
 ```bash
 > make sim
@@ -70,10 +70,10 @@ The simulator can be build with *Make*. By default this will build the simulator
 
 ### Building with CMake
 
-CMake may also be used to build the simulator. To do this from the `qiskit-sdk-py` directory run
+CMake may also be used to build the simulator. To do this from the `qiskit-core` directory run
 
 ```bash
-qiskit-sdk-py> mkdir out; cd out; cmake ..; make
+qiskit-core> mkdir out; cd out; cmake ..; make
 ```
 
 To build with CMake on MacOS follow the specific instructions:
@@ -98,13 +98,13 @@ This will install GCC7 without overriding Apples XCode compiler. It can be invok
 If building with CMake using the Apple XCode compiler for building you must add an additional flag to disable static linking:
 
 ```bash
-qiskit-sdk-py> mkdir out; cd out; cmake -DSTATIC_LINKING=False ..; make
+qiskit-core> mkdir out; cd out; cmake -DSTATIC_LINKING=False ..; make
 ```
 
 To enable OpenMP support by using the GCC7 compiler installed with Homebrew run:
 
 ```bash
-qiskit-sdk-py> mkdir out; cd out; cmake -DCMAKE_CXX_COMPILER=g++-7 ..; make
+qiskit-core> mkdir out; cd out; cmake -DCMAKE_CXX_COMPILER=g++-7 ..; make
 ```
 
 #### Installation on Ubuntu 16.04 LTS
@@ -161,7 +161,7 @@ qobj = {...}  # qobj as a Python dictionary
 result = qs.run(qobj, path=SIM_EXECUTABLE)  # result json as a Python dictionary
 ```
 
-### Running as a backend for qiskit-sdk-py
+### Running as a backend for qiskit-core
 
 This simulator can also be used as a backend for the QISKit Python SDK.  This is handled automatically when importing the `qiskit` module. After importing the module the simulator may be run as follows:
 
@@ -208,7 +208,7 @@ By default the simulator prints a JSON file to the standard output. If called th
 
 The `"result"` key is a list of the output of each circuit in the qobj: If the qobj contains *n* circuits, `"result"` will be a length *n* list. The results for each individual circuit are obtained by the `"data"` key in the circuit result object. Be default this will be a dictionary `"counts"` of measurement counts. Additional simulation data may be returned by using config settings discussed in the config settings section.
 
-#### qiskit-sdk-py output
+#### qiskit-core output
 
 If the simulator is called though the Python QISKit SDK the input qobj will only contain a single circuit, and only the values in the `"data"` field will be accessible in the `Results` object. The dictionary of this data may be accessed using the `Results.get_data('name')` method.
 

--- a/src/qasm-simulator-cpp/build_dependencies.sh
+++ b/src/qasm-simulator-cpp/build_dependencies.sh
@@ -3,7 +3,7 @@
 # ------------------------------------------------------------------------------
 # build_dependencies.sh
 # 
-# Dependency installer for qiskit-sdk-py/src/qasm-simulator-cpp
+# Dependency installer for qiskit-core/src/qasm-simulator-cpp
 # Running the script:
 #   1. Run the script directly
 #     ./build_dependencies.sh  

--- a/test/python/_dummybackend.py
+++ b/test/python/_dummybackend.py
@@ -56,7 +56,7 @@ class DummySimulator(BaseBackend):
 
     DEFAULT_CONFIGURATION = {
         'name': 'local_dummy_simulator',
-        'url': 'https://github.com/IBM/qiskit-sdk-py',
+        'url': 'https://github.com/QISKit/qiskit-core',
         'simulator': True,
         'local': True,
         'description': 'A dummy simulator for testing purposes',

--- a/test/python/qasm/math_domain_error.qasm
+++ b/test/python/qasm/math_domain_error.qasm
@@ -1,5 +1,5 @@
 OPENQASM 2.0;
-// https://github.com/QISKit/qiskit-sdk-py/issues/111
+// https://github.com/QISKit/qiskit-core/issues/111
 include "qelib1.inc";
 qreg q[4];
 creg c[4];

--- a/test/python/qasm/overoptimization.qasm
+++ b/test/python/qasm/overoptimization.qasm
@@ -1,5 +1,5 @@
 OPENQASM 2.0;
-// https://github.com/QISKit/qiskit-sdk-py/issues/81
+// https://github.com/QISKit/qiskit-core/issues/81
 include "qelib1.inc";
 qreg q[4];
 creg c[4];

--- a/test/python/test_mapper.py
+++ b/test/python/test_mapper.py
@@ -33,7 +33,7 @@ class MapperTest(QiskitTestCase):
     def test_mapper_overoptimization(self):
         """
         The mapper should not change the semantics of the input. An overoptimization introduced
-        the issue #81: https://github.com/QISKit/qiskit-sdk-py/issues/81
+        the issue #81: https://github.com/QISKit/qiskit-core/issues/81
         """
         self.qp.load_qasm_file(self._get_resource_path('qasm/overoptimization.qasm'), name='test')
         coupling_map = [[0, 2], [1, 2], [2, 3]]
@@ -48,7 +48,7 @@ class MapperTest(QiskitTestCase):
         """
         The math library operates over floats and introduce floating point errors that should be
         avoided.
-        See: https://github.com/QISKit/qiskit-sdk-py/issues/111
+        See: https://github.com/QISKit/qiskit-core/issues/111
         """
         self.qp.load_qasm_file(self._get_resource_path('qasm/math_domain_error.qasm'), name='test')
         coupling_map = [[0, 2], [1, 2], [2, 3]]
@@ -64,7 +64,7 @@ class MapperTest(QiskitTestCase):
     def test_optimize_1q_gates_issue159(self):
         """Test change in behavior for optimize_1q_gates that removes u1(2*pi) rotations.
 
-        See: https://github.com/QISKit/qiskit-sdk-py/issues/159
+        See: https://github.com/QISKit/qiskit-core/issues/159
         """
         self.qp = QuantumProgram()
         qr = self.qp.create_quantum_register('qr', 2)
@@ -133,7 +133,7 @@ class MapperTest(QiskitTestCase):
     def test_symbolic_unary(self):
         """Test symbolic math in DAGBackend and optimizer with a prefix.
 
-        See: https://github.com/QISKit/qiskit-sdk-py/issues/172
+        See: https://github.com/QISKit/qiskit-core/issues/172
         """
         ast = qasm.Qasm(filename=self._get_resource_path(
             'qasm/issue172_unary.qasm')).parse()
@@ -145,7 +145,7 @@ class MapperTest(QiskitTestCase):
     def test_symbolic_binary(self):
         """Test symbolic math in DAGBackend and optimizer with a binary operation.
 
-        See: https://github.com/QISKit/qiskit-sdk-py/issues/172
+        See: https://github.com/QISKit/qiskit-core/issues/172
         """
         ast = qasm.Qasm(filename=self._get_resource_path(
             'qasm/issue172_binary.qasm')).parse()
@@ -158,7 +158,7 @@ class MapperTest(QiskitTestCase):
     def test_symbolic_extern(self):
         """Test symbolic math in DAGBackend and optimizer with an external function.
 
-        See: https://github.com/QISKit/qiskit-sdk-py/issues/172
+        See: https://github.com/QISKit/qiskit-core/issues/172
         """
         ast = qasm.Qasm(filename=self._get_resource_path(
             'qasm/issue172_extern.qasm')).parse()
@@ -170,7 +170,7 @@ class MapperTest(QiskitTestCase):
     def test_symbolic_power(self):
         """Test symbolic math in DAGBackend and optimizer with a power (^).
 
-        See: https://github.com/QISKit/qiskit-sdk-py/issues/172
+        See: https://github.com/QISKit/qiskit-core/issues/172
         """
         ast = qasm.Qasm(data=QASM_SYMBOLIC_POWER).parse()
         unr = unroll.Unroller(ast, backend=unroll.DAGBackend(["cx", "u1", "u2", "u3"]))
@@ -181,7 +181,7 @@ class MapperTest(QiskitTestCase):
     def test_already_mapped(self):
         """Test that if the circuit already matches the backend topology, it is not remapped.
 
-        See: https://github.com/QISKit/qiskit-sdk-py/issues/342
+        See: https://github.com/QISKit/qiskit-core/issues/342
         """
         self.qp = QuantumProgram()
         qr = self.qp.create_quantum_register('qr', 16)

--- a/test/python/test_quantumprogram.py
+++ b/test/python/test_quantumprogram.py
@@ -1653,7 +1653,7 @@ class TestQuantumProgram(QiskitTestCase):
     def test_ccx(self):
         """Checks a Toffoli gate.
 
-        Based on https://github.com/QISKit/qiskit-sdk-py/pull/172.
+        Based on https://github.com/QISKit/qiskit-core/pull/172.
         """
         Q_program = QuantumProgram()
         q = Q_program.create_quantum_register('q', 3)


### PR DESCRIPTION
## Description

Rename all references to `qiskit-sdk-py` to the new repository name,
`QISKit/qiskit-core`, including a handful of instances where the
`IBM/qiskit-sdk-py` form was used.

Fixes #467 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.