### PR TITLE
fix circuit_drawer for linux/mac

### DIFF
--- a/qiskit/tools/visualization.py
+++ b/qiskit/tools/visualization.py
@@ -731,12 +731,12 @@ def circuit_drawer(circuit,
                                'Skipping circuit drawing...')
         else:
             try:
+                base = os.path.join(tmpdirname, filename)
                 subprocess.run(["pdftocairo", "-singlefile", "-png", "-q",
-                                "{}".format(os.path.join(tmpdirname, filename + '.pdf'))])
-                pngfile = os.path.join(tmpdirname, "{0}.png".format(filename))
-                im = Image.open(pngfile)
+                                base + '.pdf', base])
+                im = Image.open(base + '.png')
                 im = trim(im)
-                os.remove(pngfile)
+                os.remove(base + '.png')
             except OSError as e:
                 if e.errno == os.errno.ENOENT:
                     logger.warning('WARNING: Unable to convert pdf to image. '


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
PR #543 fixed an issue with filenames on Windows by adding absolute paths. But it broke circuit_drawer functionality on Mac/Linux. This PR fixes that. The absolute paths are still preserved.


### Details and comments
The underlying issue was that when doing conversion from `pdf` to `png`, the output file location was not explicitly set. This is now explicit, avoiding inconsistencies between platforms.

