### PR TITLE
Avoid double registration of same provider/credentials

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -32,7 +32,7 @@ Removed
 
 Fixed
 -----
-
+- Fix possible double registeration of same provider with same credentials (#566)
 
 `0.5.4`_ - 2018-06-11
 =====================

--- a/qiskit/backends/ibmq/ibmqprovider.py
+++ b/qiskit/backends/ibmq/ibmqprovider.py
@@ -19,6 +19,14 @@ class IBMQProvider(BaseProvider):
                  hub=None, group=None, project=None, proxies=None, verify=True):
         super().__init__()
 
+        self._token = token
+        self._url = url
+        self._hub = hub
+        self._group = group
+        self._project = project
+        self._proxies = proxies
+        self._verify = verify
+
         # Get a connection to IBMQuantumExperience.
         self._api = self._authenticate(token, url,
                                        hub, group, project, proxies, verify)
@@ -124,3 +132,12 @@ class IBMQProvider(BaseProvider):
             ret[config['name']] = IBMQBackend(configuration=config, api=self._api)
 
         return ret
+
+    def __eq__(self, other):
+        try:
+            equality = (self._token == other._token and self._url == other._url and
+                        self._hub == other._hub and self._group == other._group and
+                        self._project == other._project)
+        except AttributeError:
+            equality = False
+        return equality

--- a/qiskit/wrapper/defaultqiskitprovider.py
+++ b/qiskit/wrapper/defaultqiskitprovider.py
@@ -85,10 +85,15 @@ class DefaultQISKitProvider(BaseProvider):
         """
         Add a new provider to the list of known providers.
 
+        If the same provider (same credentials etc.) has been previously
+        added, skip.
+
         Args:
             provider (BaseProvider): Provider instance.
         """
-        self.providers.append(provider)
+        already_added = any([provider == p for p in self.providers])
+        if not already_added:
+            self.providers.append(provider)
 
     def resolve_backend_name(self, name):
         """Resolve backend name from a possible short alias or a deprecated name.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
If I call `register(token, url)` with the same credentials 5 times, the same provider gets added to the wrapper's `DefaultQISKitProvider` 5 times, and I will see 5 `ibmqx2` devices when I write `available_backends(compact=False)`.

This PR checks to make sure double registration does not happen.

### Details and comments


