### PR TITLE
Fixing undefined variable in docs related to getting results from real chips (backends)

### DIFF
--- a/doc/example_real_backend.rst
+++ b/doc/example_real_backend.rst
@@ -37,7 +37,7 @@ Quantum device:
 
     # Compile and run the Quantum Program on a real device backend
     job_exp = execute(qc, 'ibmqx4', shots=1024, max_credits=10)
-    result = job.result()
+    result = job_exp.result()
 
     # Show the results
     print(result)
@@ -90,7 +90,7 @@ the IBM Q features:
 
     # Compile and run the Quantum Program on a real device backend
     job_exp = execute(qc, 'ibmqx4', shots=1024, max_credits=10)
-    result = job.result()
+    result = job_exp.result()
 
     # Show the results
     print(result)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
The variable `job` in the statement `job.result()` has not been declared previously. 
Fixed changing `job` variable to `job_exp` as required in the issue #570 


### Details and comments

- 
