### PR TITLE
Fix initializer gate inversion

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -32,6 +32,7 @@ Removed
 
 Fixed
 -----
+- Fix issue with unintended inversion of initializer gates (#573).
 
 
 `0.5.4`_ - 2018-06-11

--- a/qiskit/extensions/quantum_initializer/_initializer.py
+++ b/qiskit/extensions/quantum_initializer/_initializer.py
@@ -75,6 +75,9 @@ class InitializeGate(CompositeGate):
         # invert the circuit to create the desired vector from zero (assuming
         # the qubits are in the zero state)
         self.inverse()
+        # do not set the inverse flag, as this is the actual initialize gate
+        # we just used inverse() as a method to obtain it
+        self.inverse_flag = False
 
     def nth_qubit_from_least_sig_qubit(self, nth):
         """
@@ -91,7 +94,7 @@ class InitializeGate(CompositeGate):
 
     def reapply(self, circ):
         """Reapply this gate to the corresponding qubits in circ."""
-        circ.initialize(self.param, self.arg)
+        self._modifiers(circ.initialize(self.param, self.arg))
 
     def gates_to_uncompute(self):
         """


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Fixes a bug in the arbitrary-state initializer gate that affected its inversion.
Fixes #572.
Fixes #507.

### Details and comments
`InitializeGate` inherits from `CompositeGate`, which has an `inverse_flag` property to signal that it has been inverted (this property is useful, for instance, in reapplying the gate to some circuit).

Our initialize gate has been implemented based on https://arxiv.org/abs/quant-ph/0406176v5. The implementation details are that it begins from the desired state, and evolves it to the zero state. The final initializer gate is thus the inverse of this process. 

This means that a call to `inverse()` is made during the implementation, which inadvertently sets the `inverse_flag` property of the gate. Here, we unset this flag.

This PR also undoes the change made in #534. That change had fixed part of the issue, but not the fundamental problem.
