### PR TITLE
Fix calibration parameters parsing

### DIFF
--- a/qiskit/backends/ibmq/ibmqbackend.py
+++ b/qiskit/backends/ibmq/ibmqbackend.py
@@ -71,7 +71,7 @@ class IBMQBackend(BaseBackend):
             calibrations = self._api.backend_calibration(backend_name)
             # FIXME a hack to remove calibration data that is none.
             # Needs to be fixed in api
-            if backend_name == 'ibmq_qasm_simulator':
+            if backend_name in ('ibmq_qasm_simulator', 'ibmqx_qasm_simulator'):
                 calibrations = {}
         except Exception as ex:
             raise LookupError(


### PR DESCRIPTION
Fix the handling of calibration parameters during
`IBMQBackend.parameters()` in order to have the same behaviour both
in QX and in client.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


