### PR TITLE
Use fixed Python version on travis osx

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,11 +62,13 @@ stage_osx: &stage_osx
     # installed manually.
     |
     if [ ${TRAVIS_OS_NAME} = "osx" ]; then
-      brew upgrade python3
       brew install gcc@6
       brew link --overwrite gcc@6
-      virtualenv env -p python3
-      source env/bin/activate
+      brew install pyenv
+      brew install pyenv-virtualenv
+      pyenv install 3.6.5
+      pyenv 3.6.5 env
+      pyenv activate env
     fi
 
 stage_linux_no_compile: &stage_linux_no_compile
@@ -134,7 +136,7 @@ jobs:
       <<: *stage_linux
       python: 3.6
 
-    # OSX, Python 3.latest (brew does not support versioning)
+    # OSX, Python 3.6.5 (via pyenv)
     - stage: test
       <<: *stage_osx
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,7 @@ stage_osx: &stage_osx
       brew link --overwrite gcc@6
       brew upgrade pyenv || brew install pyenv
       pyenv install 3.6.5
-      python3.6 -m venv venv
+      ~/.pyenv/versions/3.6.5/bin/python -m venv venv
       source venv/bin/activate
     fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,10 +65,9 @@ stage_osx: &stage_osx
       brew install gcc@6
       brew link --overwrite gcc@6
       brew install pyenv
-      brew install pyenv-virtualenv
       pyenv install 3.6.5
-      pyenv virtualenv 3.6.5 env
-      pyenv activate env
+      python3.6 -m venv venv
+      source venv/bin/activate
     fi
 
 stage_linux_no_compile: &stage_linux_no_compile

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,7 +64,7 @@ stage_osx: &stage_osx
     if [ ${TRAVIS_OS_NAME} = "osx" ]; then
       brew install gcc@6
       brew link --overwrite gcc@6
-      brew install pyenv
+      brew upgrade pyenv || brew install pyenv
       pyenv install 3.6.5
       python3.6 -m venv venv
       source venv/bin/activate

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,7 +67,7 @@ stage_osx: &stage_osx
       brew install pyenv
       brew install pyenv-virtualenv
       pyenv install 3.6.5
-      pyenv 3.6.5 env
+      pyenv virtualenv 3.6.5 env
       pyenv activate env
     fi
 


### PR DESCRIPTION
Fix the travis python version to 3.6.5 using `pyenv`, as the current
runs use Python 3.7 which seems to cause some issues in some of the
dependencies.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments

The latest travis osx runs (since ~yesterday) are picking Python 3.7, which seem to be a source of issues.

